### PR TITLE
Fix lint errors in test_utils

### DIFF
--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -3,12 +3,20 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-
-from .tests_helper import dump_data_and_model
-from .tests_helper import dump_one_class_classification, dump_binary_classification, dump_multiple_classification
-from .tests_helper import dump_multiple_regression, dump_single_regression
-
 import numpy as np
+
+from .tests_helper import dump_data_and_model  # noqa
+from .tests_helper import (  # noqa
+    dump_one_class_classification,
+    dump_binary_classification,
+    dump_multiple_classification,
+)
+from .tests_helper import (  # noqa
+    dump_multiple_regression,
+    dump_single_regression,
+)
+
+
 def create_tensor(N, C, H=None, W=None):
     if H is None and W is None:
         return np.random.rand(N, C).astype(np.float32, copy=False)

--- a/tests/test_utils/main.py
+++ b/tests/test_utils/main.py
@@ -1,8 +1,8 @@
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
-#--------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 
 from skl2onnx.proto import onnx_proto
 from skl2onnx.common import utils as convert_utils
@@ -56,7 +56,8 @@ def set_model_doc_string(model, doc, override=False):
 
     :param model: instance of an ONNX model
     :param doc: string containing the doc string that describes the model.
-    :param override: bool if true will always override the doc string with the new value
+    :param override: bool if true will always override the doc
+        string with the new value
 
     Example:
 
@@ -70,5 +71,8 @@ def set_model_doc_string(model, doc, override=False):
     if not convert_utils.is_string_type(doc):
         raise ValueError("doc must be a string type")
     if model.doc_string and not doc and override is False:
-        raise ValueError("failing to overwrite the doc string with a blank string, set override to True if intentional")
+        raise ValueError(
+            "failing to overwrite the doc string with a blank string,"
+            " set override to True if intentional"
+        )
     model.doc_string = doc

--- a/tests/test_utils/tests_helper.py
+++ b/tests/test_utils/tests_helper.py
@@ -1,8 +1,8 @@
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
-#--------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 import pickle
 import os
 import warnings
@@ -13,32 +13,49 @@ import platform
 import numpy
 import pandas
 from sklearn.base import BaseEstimator
-from .utils_backend import compare_backend, extract_options, evaluate_condition, is_backend_enabled
+from .utils_backend import (
+    compare_backend,
+    extract_options,
+    evaluate_condition,
+    is_backend_enabled,
+)
 from skl2onnx.common.data_types import FloatTensorType
 
 
 def _has_predict_proba(model):
-    if hasattr(model, 'voting') and model.voting == 'hard':
+    if hasattr(model, "voting") and model.voting == "hard":
         return False
     return hasattr(model, "predict_proba")
 
-    
+
 def _has_decision_function(model):
-    if hasattr(model, 'voting'):
+    if hasattr(model, "voting"):
         return False
     return hasattr(model, "decision_function")
 
-    
+
 def _has_transform_model(model):
-    if hasattr(model, 'voting'):
+    if hasattr(model, "voting"):
         return False
     return hasattr(model, "fit_transform") and hasattr(model, "score")
-    
 
-def dump_data_and_model(data, model, onnx=None, basename="model", folder=None,
-                        inputs=None, backend="onnxruntime", context=None,
-                        allow_failure=None, methods=None, dump_error_log=None, benchmark=None,
-                        comparable_outputs=None, verbose=False):
+
+def dump_data_and_model(
+        data,
+        model,
+        onnx=None,
+        basename="model",
+        folder=None,
+        inputs=None,
+        backend="onnxruntime",
+        context=None,
+        allow_failure=None,
+        methods=None,
+        dump_error_log=None,
+        benchmark=None,
+        comparable_outputs=None,
+        verbose=False,
+):
     """
     Saves data with pickle, saves the model with pickle and *onnx*,
     runs and saves the predictions for the given model.
@@ -65,10 +82,12 @@ def dump_data_and_model(data, model, onnx=None, basename="model", folder=None,
         for the backends, otherwise a string which is then evaluated to check
         whether or not the test can fail, example:
         ``"StrictVersion(onnx.__version__) < StrictVersion('1.3.0')"``
-    :param dump_error_log: if True, dumps any error message in a file  ``<basename>.err``,
-        if it is None, it checks the environment variable ``ONNXTESTDUMPERROR``
-    :param benchmark: if True, runs a benchmark and stores the results into a file
-        ``<basename>.bench``, if None, it checks the environment variable ``ONNXTESTBENCHMARK``
+    :param dump_error_log: if True, dumps any error message in a file
+        ``<basename>.err``, if it is None, it checks the environment
+         variable ``ONNXTESTDUMPERROR``
+    :param benchmark: if True, runs a benchmark and stores the results
+        into a file ``<basename>.bench``, if None, it checks the environment
+        variable ``ONNXTESTBENCHMARK``
     :param verbose: additional information
     :param methods: ONNX may produce one or several results, each of them
         is equivalent to the output of a method from the model class,
@@ -84,44 +103,60 @@ def dump_data_and_model(data, model, onnx=None, basename="model", folder=None,
     The name can contain some flags. Expected outputs refer to the
     outputs computed with the original library, computed outputs
     refer to the outputs computed with a ONNX runtime.
-    
-    * ``-CannotLoad``: the model can be converted but the runtime cannot load it
-    * ``-Dec3``: compares expected and computed outputs up to 3 decimals (5 by default)
-    * ``-Dec4``: compares expected and computed outputs up to 4 decimals (5 by default)    
-    * ``-NoProb``: The original models computed probabilites for two classes *size=(N, 2)*
-      but the runtime produces a vector of size *N*, the test will compare the second column
-      to the column
-    * ``-OneOff``: the ONNX runtime cannot compute the prediction for several inputs,
-      it must be called for each of them.
-    * ``-OneOffArray``: same as ``-OneOff`` but input is still a 2D array with one observation
+
+    * ``-CannotLoad``: the model can be converted but the runtime
+      cannot load it
+    * ``-Dec3``: compares expected and computed outputs up to
+      3 decimals (5 by default)
+    * ``-Dec4``: compares expected and computed outputs up to
+      4 decimals (5 by default)
+    * ``-NoProb``: The original models computed probabilites for two classes
+      *size=(N, 2)* but the runtime produces a vector of size *N*, the test
+      will compare the second column to the column
+    * ``-OneOff``: the ONNX runtime cannot compute the prediction for
+      several inputs, it must be called for each of them.
+    * ``-OneOffArray``: same as ``-OneOff`` but input is still a 2D array
+      with one observation
     * ``-Out0``: only compares the first output on both sides
-    * ``-Reshape``: merges all outputs into one single vector and resizes it before comparing
+    * ``-Reshape``: merges all outputs into one single vector and resizes
+      it before comparing
     * ``-SkipDim1``: before comparing expected and computed output,
       arrays with a shape like *(2, 1, 2)* becomes *(2, 2)*
-    * ``-SklCol``: *scikit-learn* operator applies on a column and not a matrix      
-    
+    * ``-SklCol``: *scikit-learn* operator applies on a column and not a matrix
+
     If the *backend* is not None, the function either raises an exception
     if the comparison between the expected outputs and the backend outputs
     fails or it saves the backend output and adds it to the results.
     """
     runtime_test = dict(model=model, data=data)
-    
+
     if folder is None:
-        folder = os.environ.get('ONNXTESTDUMP', 'tests_dump')
+        folder = os.environ.get("ONNXTESTDUMP", "tests_dump")
     if dump_error_log is None:
-        dump_error_log = os.environ.get('ONNXTESTDUMPERROR', '0') in ('1', 1, 'True', 'true', True)
+        dump_error_log = os.environ.get("ONNXTESTDUMPERROR", "0") in (
+            "1",
+            1,
+            "True",
+            "true",
+            True,
+        )
     if benchmark is None:
-        benchmark = os.environ.get('ONNXTESTBENCHMARK', '0') in ('1', 1, 'True', 'true', True)
+        benchmark = os.environ.get("ONNXTESTBENCHMARK", "0") in (
+            "1",
+            1,
+            "True",
+            "true",
+            True,
+        )
     if not os.path.exists(folder):
         os.makedirs(folder)
-    
+
     lambda_original = None
-    lambda_onnxrt = None
     if isinstance(data, (numpy.ndarray, pandas.DataFrame)):
         dataone = data[:1].copy()
     else:
         dataone = data
-    
+
     if methods is not None:
         prediction = []
         for method in methods:
@@ -129,53 +164,61 @@ def dump_data_and_model(data, model, onnx=None, basename="model", folder=None,
             if callable(call):
                 prediction.append(call(data))
                 # we only take the last one for benchmark
-                lambda_original = lambda: call(dataone)
+                lambda_original = lambda: call(dataone)  # NOQA
             else:
-                raise RuntimeError("Method '{0}' is not callable.".format(method))
+                raise RuntimeError(
+                    "Method '{0}' is not callable.".format(method))
     else:
         if hasattr(model, "predict"):
             if _has_predict_proba(model):
                 # Classifier
                 prediction = [model.predict(data), model.predict_proba(data)]
-                lambda_original = lambda: model.predict_proba(dataone)
+                lambda_original = lambda: model.predict_proba(dataone)  # NOQA
             elif _has_decision_function(model):
                 # Classifier without probabilities
-                prediction = [model.predict(data), model.decision_function(data)]
-                lambda_original = lambda: model.decision_function(dataone)
+                prediction = [
+                    model.predict(data),
+                    model.decision_function(data),
+                ]
+                lambda_original = (
+                    lambda: model.decision_function(dataone))  # NOQA
             elif _has_transform_model(model):
                 # clustering
-                prediction = [model.predict(data), model.transform(data)]            
-                lambda_original = lambda: model.transform(dataone)
+                prediction = [model.predict(data), model.transform(data)]
+                lambda_original = lambda: model.transform(dataone)  # NOQA
             else:
                 # Regressor or VotingClassifier
                 prediction = [model.predict(data)]
-                lambda_original = lambda: model.predict(dataone)
+                lambda_original = lambda: model.predict(dataone)  # NOQA
+
         elif hasattr(model, "transform"):
             options = extract_options(basename)
-            SklCol = options.get('SklCol', False)
+            SklCol = options.get("SklCol", False)
             if SklCol:
                 prediction = model.transform(data.ravel())
-                lambda_original = lambda: model.transform(dataone.ravel())
+                lambda_original = lambda: model.transform(dataone.ravel())  # NOQA
             else:
                 prediction = model.transform(data)
-                lambda_original = lambda: model.transform(dataone)
+                lambda_original = lambda: model.transform(dataone)  # NOQA
         else:
-            raise TypeError("Model has not predict or transform method: {0}".format(type(model)))
+            raise TypeError(
+                "Model has not predict or transform method: {0}".format(
+                    type(model)))
 
-    runtime_test['expected'] = prediction
-    
+    runtime_test["expected"] = prediction
+
     names = []
     dest = os.path.join(folder, basename + ".expected.pkl")
     names.append(dest)
     with open(dest, "wb") as f:
         pickle.dump(prediction, f)
-    
+
     dest = os.path.join(folder, basename + ".data.pkl")
     names.append(dest)
     with open(dest, "wb") as f:
         pickle.dump(data, f)
-    
-    if hasattr(model, 'save'):
+
+    if hasattr(model, "save"):
         dest = os.path.join(folder, basename + ".model.keras")
         names.append(dest)
         model.save(dest)
@@ -184,25 +227,25 @@ def dump_data_and_model(data, model, onnx=None, basename="model", folder=None,
         names.append(dest)
         with open(dest, "wb") as f:
             pickle.dump(model, f)
-    
+
     if dump_error_log:
         error_dump = os.path.join(folder, basename + ".err")
-        
+
     if onnx is None:
         array = numpy.array(data)
         if inputs is None:
-            inputs = [('input', FloatTensorType(list(array.shape)))]
+            inputs = [("input", FloatTensorType(list(array.shape)))]
         onnx, _ = convert_model(model, basename, inputs)
-    
+
     dest = os.path.join(folder, basename + ".model.onnx")
     names.append(dest)
     with open(dest, "wb") as f:
         f.write(onnx.SerializeToString())
     if verbose:
         print("[dump_data_and_model] created '{}'.".format(dest))
-    
+
     runtime_test["onnx"] = dest
-    
+
     # backend
     if backend is not None:
         if not isinstance(backend, list):
@@ -215,103 +258,158 @@ def dump_data_and_model(data, model, onnx=None, basename="model", folder=None,
             else:
                 allow = allow_failure
             if allow is None:
-                output, lambda_onnx = compare_backend(b, runtime_test, options=extract_options(basename),
-                                                      context=context, verbose=verbose,
-                                                      comparable_outputs=comparable_outputs)
+                output, lambda_onnx = compare_backend(
+                    b,
+                    runtime_test,
+                    options=extract_options(basename),
+                    context=context,
+                    verbose=verbose,
+                    comparable_outputs=comparable_outputs,
+                )
             else:
                 try:
-                    output, lambda_onnx = compare_backend(b, runtime_test, options=extract_options(basename),
-                                                          context=context, verbose=verbose,
-                                                          comparable_outputs=comparable_outputs)
+                    output, lambda_onnx = compare_backend(
+                        b,
+                        runtime_test,
+                        options=extract_options(basename),
+                        context=context,
+                        verbose=verbose,
+                        comparable_outputs=comparable_outputs,
+                    )
                 except AssertionError as e:
                     if dump_error_log:
                         with open(error_dump, "w", encoding="utf-8") as f:
                             f.write(str(e) + "\n--------------\n")
                             traceback.print_exc(file=f)
                     if isinstance(allow, bool) and allow:
-                        warnings.warn("Issue with '{0}' due to {1}".format(basename, str(e).replace("\n", " -- ")))
+                        warnings.warn("Issue with '{0}' due to {1}".format(
+                            basename,
+                            str(e).replace("\n", " -- ")))
                         continue
                     else:
                         raise e
 
             if output is not None:
-                dest = os.path.join(folder, basename + ".backend.{0}.pkl".format(b))
+                dest = os.path.join(folder,
+                                    basename + ".backend.{0}.pkl".format(b))
                 names.append(dest)
                 with open(dest, "wb") as f:
                     pickle.dump(output, f)
-                if benchmark and lambda_onnx is not None and lambda_original is not None:
+                if (benchmark and lambda_onnx is not None
+                        and lambda_original is not None):
                     # run a benchmark
-                    obs = compute_benchmark({'onnxrt': lambda_onnx, 'original': lambda_original})
+                    obs = compute_benchmark({
+                        "onnxrt": lambda_onnx,
+                        "original": lambda_original
+                    })
                     df = pandas.DataFrame(obs)
                     df["input_size"] = sys.getsizeof(dataone)
                     dest = os.path.join(folder, basename + ".bench")
                     df.to_csv(dest, index=False)
-        
+
     return names
 
 
 def convert_model(model, name, input_types):
     """
     Runs the appropriate conversion method.
-    
-    :param model: model, *scikit-learn*, *keras*, or *coremltools* object
+
+    :param model: model, *scikit-learn*, *keras*,
+         or *coremltools* object
     :return: *onnx* model
     """
-    from sklearn.base import BaseEstimator
     from skl2onnx import convert_sklearn
+
     model, prefix = convert_sklearn(model, name, input_types), "Sklearn"
     if model is None:
-        raise RuntimeError("Unable to convert model of type '{0}'.".format(type(model)))
+        raise RuntimeError("Unable to convert model of type '{0}'.".format(
+            type(model)))
     return model, prefix
 
-    
-def dump_one_class_classification(model, suffix="", folder=None, allow_failure=None,
-                                 comparable_outputs=None, verbose=False):
+
+def dump_one_class_classification(
+        model,
+        suffix="",
+        folder=None,
+        allow_failure=None,
+        comparable_outputs=None,
+        verbose=False,
+):
     """
     Trains and dumps a model for a One Class outlier problem.
     The function trains a model and calls
     :func:`dump_data_and_model`.
-    
+
     Every created filename will follow the pattern:
     ``<folder>/<prefix><task><classifier-name><suffix>.<data|expected|model|onnx>.<pkl|onnx>``.
     """
-    X = [[0., 1.], [1., 1.], [2., 0.]]
+    X = [[0.0, 1.0], [1.0, 1.0], [2.0, 0.0]]
     X = numpy.array(X, dtype=numpy.float32)
     y = [1, 1, 1]
     model.fit(X, y)
-    model_onnx, prefix = convert_model(model, 'one_class', [('input', FloatTensorType([1, 2]))])
-    return dump_data_and_model(X, model, model_onnx, folder=folder, allow_failure=allow_failure,
-                               basename=prefix + "One" + model.__class__.__name__ + suffix,
-                               verbose=verbose, comparable_outputs=comparable_outputs)
+    model_onnx, prefix = convert_model(model, "one_class",
+                                       [("input", FloatTensorType([1, 2]))])
+    return dump_data_and_model(
+        X,
+        model,
+        model_onnx,
+        folder=folder,
+        allow_failure=allow_failure,
+        basename=prefix + "One" + model.__class__.__name__ + suffix,
+        verbose=verbose,
+        comparable_outputs=comparable_outputs,
+    )
 
 
-def dump_binary_classification(model, suffix="", folder=None, allow_failure=None,
-                               comparable_outputs=None, verbose=False):
+def dump_binary_classification(
+        model,
+        suffix="",
+        folder=None,
+        allow_failure=None,
+        comparable_outputs=None,
+        verbose=False,
+):
     """
     Trains and dumps a model for a binary classification problem.
     The function trains a model and calls
     :func:`dump_data_and_model`.
-    
+
     Every created filename will follow the pattern:
     ``<folder>/<prefix><task><classifier-name><suffix>.<data|expected|model|onnx>.<pkl|onnx>``.
     """
     X = [[0, 1], [1, 1], [2, 0]]
     X = numpy.array(X, dtype=numpy.float32)
-    y = ['A', 'B', 'A']
+    y = ["A", "B", "A"]
     model.fit(X, y)
-    model_onnx, prefix = convert_model(model, 'binary classifier', [('input', FloatTensorType([1, 2]))])
-    dump_data_and_model(X, model, model_onnx, folder=folder, allow_failure=allow_failure,
-                        basename=prefix + "Bin" + model.__class__.__name__ + suffix,
-                        verbose=verbose, comparable_outputs=comparable_outputs)
+    model_onnx, prefix = convert_model(model, "binary classifier",
+                                       [("input", FloatTensorType([1, 2]))])
+    dump_data_and_model(
+        X,
+        model,
+        model_onnx,
+        folder=folder,
+        allow_failure=allow_failure,
+        basename=prefix + "Bin" + model.__class__.__name__ + suffix,
+        verbose=verbose,
+        comparable_outputs=comparable_outputs,
+    )
 
-def dump_multiple_classification(model, suffix="", folder=None, allow_failure=None,
-                                 verbose=False, label_string=False, first_class=0,
-                                 comparable_outputs=None):
+
+def dump_multiple_classification(
+        model,
+        suffix="",
+        folder=None,
+        allow_failure=None,
+        verbose=False,
+        label_string=False,
+        first_class=0,
+        comparable_outputs=None,
+):
     """
     Trains and dumps a model for a binary classification problem.
     The function trains a model and calls
     :func:`dump_data_and_model`.
-    
+
     Every created filename will follow the pattern:
     ``<folder>/<prefix><task><classifier-name><suffix>.<data|expected|model|onnx>.<pkl|onnx>``.
     """
@@ -323,22 +421,37 @@ def dump_multiple_classification(model, suffix="", folder=None, allow_failure=No
         y = ["l%d" % i for i in y]
     model.fit(X, y)
     if verbose:
-        print("[dump_multiple_classification] model '{}'".format(model.__class__.__name__))
-    model_onnx, prefix = convert_model(model, 'multi-class classifier', [('input', FloatTensorType([1, 2]))])
+        print("[dump_multiple_classification] model '{}'".format(
+            model.__class__.__name__))
+    model_onnx, prefix = convert_model(model, "multi-class classifier",
+                                       [("input", FloatTensorType([1, 2]))])
     if verbose:
         print("[dump_multiple_classification] model was converted")
-    dump_data_and_model(X, model, model_onnx, folder=folder, allow_failure=allow_failure,
-                        basename=prefix + "Mcl" + model.__class__.__name__ + suffix,
-                        verbose=verbose, comparable_outputs=comparable_outputs)
+    dump_data_and_model(
+        X,
+        model,
+        model_onnx,
+        folder=folder,
+        allow_failure=allow_failure,
+        basename=prefix + "Mcl" + model.__class__.__name__ + suffix,
+        verbose=verbose,
+        comparable_outputs=comparable_outputs,
+    )
 
 
-def dump_multiple_regression(model, suffix="", folder=None, allow_failure=None,
-                             comparable_outputs=None, verbose=False):
+def dump_multiple_regression(
+        model,
+        suffix="",
+        folder=None,
+        allow_failure=None,
+        comparable_outputs=None,
+        verbose=False,
+):
     """
     Trains and dumps a model for a multi regression problem.
     The function trains a model and calls
     :func:`dump_data_and_model`.
-    
+
     Every created filename will follow the pattern:
     ``<folder>/<prefix><task><classifier-name><suffix>.<data|expected|model|onnx>.<pkl|onnx>``.
     """
@@ -346,18 +459,30 @@ def dump_multiple_regression(model, suffix="", folder=None, allow_failure=None,
     X = numpy.array(X, dtype=numpy.float32)
     y = numpy.array([[100, 50], [100, 49], [100, 99]], dtype=numpy.float32)
     model.fit(X, y)
-    model_onnx, prefix = convert_model(model, 'multi-regressor', [('input', FloatTensorType([1, 2]))])
-    dump_data_and_model(X, model, model_onnx, folder=folder, allow_failure=allow_failure,
-                        basename=prefix + "MRg" + model.__class__.__name__ + suffix,
-                        verbose=verbose, comparable_outputs=comparable_outputs)
+    model_onnx, prefix = convert_model(model, "multi-regressor",
+                                       [("input", FloatTensorType([1, 2]))])
+    dump_data_and_model(
+        X,
+        model,
+        model_onnx,
+        folder=folder,
+        allow_failure=allow_failure,
+        basename=prefix + "MRg" + model.__class__.__name__ + suffix,
+        verbose=verbose,
+        comparable_outputs=comparable_outputs,
+    )
 
 
-def dump_single_regression(model, suffix="", folder=None, allow_failure=None, comparable_outputs=None):
+def dump_single_regression(model,
+                           suffix="",
+                           folder=None,
+                           allow_failure=None,
+                           comparable_outputs=None):
     """
     Trains and dumps a model for a regression problem.
     The function trains a model and calls
     :func:`dump_data_and_model`.
-    
+
     Every created filename will follow the pattern:
     ``<folder>/<prefix><task><classifier-name><suffix>.<data|expected|model|onnx>.<pkl|onnx>``.
     """
@@ -365,10 +490,17 @@ def dump_single_regression(model, suffix="", folder=None, allow_failure=None, co
     X = numpy.array(X, dtype=numpy.float32)
     y = numpy.array([100, -10, 50], dtype=numpy.float32)
     model.fit(X, y)
-    model_onnx, prefix = convert_model(model, 'single regressor', [('input', FloatTensorType([1, 2]))])
-    dump_data_and_model(X, model, model_onnx, folder=folder, allow_failure=allow_failure,
-                        basename=prefix + "Reg" + model.__class__.__name__ + suffix,
-                        comparable_outputs=comparable_outputs)
+    model_onnx, prefix = convert_model(model, "single regressor",
+                                       [("input", FloatTensorType([1, 2]))])
+    dump_data_and_model(
+        X,
+        model,
+        model_onnx,
+        folder=folder,
+        allow_failure=allow_failure,
+        basename=prefix + "Reg" + model.__class__.__name__ + suffix,
+        comparable_outputs=comparable_outputs,
+    )
 
 
 def timeit_repeat(fct, number, repeat):
@@ -385,7 +517,7 @@ def timeit_repeat(fct, number, repeat):
         t2 = time.perf_counter()
         res.append(t2 - t1)
     return res
-        
+
 
 def timeexec(fct, number, repeat):
     """
@@ -407,14 +539,23 @@ def timeexec(fct, number, repeat):
     rep.sort()
     mini = rep[len(rep) // 20] / number
     maxi = rep[-len(rep) // 20] / number
-    return dict(average=ave, deviation=std, first=fir, first3=fir3,
-                last3=las3, repeat=repeat, min5=mini, max5=maxi, run=number)
+    return dict(
+        average=ave,
+        deviation=std,
+        first=fir,
+        first3=fir3,
+        last3=las3,
+        repeat=repeat,
+        min5=mini,
+        max5=maxi,
+        run=number,
+    )
 
 
 def compute_benchmark(fcts, number=10, repeat=100):
     """
     Compares the processing time several functions.
-    
+
     :param fcts: dictionary ``{'name': fct}``
     :param number: number of time to run the expression
         (and then divide by this number to get an average)
@@ -425,7 +566,7 @@ def compute_benchmark(fcts, number=10, repeat=100):
     obs = []
     for name, fct in fcts.items():
         res = timeexec(fct, number=number, repeat=repeat)
-        res['name'] = name
+        res["name"] = name
         obs.append(res)
     return obs
 
@@ -443,11 +584,11 @@ def get_nb_skl_objects(obj):
     elif isinstance(obj, dict):
         for o in obj.values():
             ct += get_nb_skl_objects(o)
-    elif isinstance(obj, BaseEstimator):        
+    elif isinstance(obj, BaseEstimator):
         for o in obj.__dict__.values():
             ct += get_nb_skl_objects(o)
     return ct
-        
+
 
 def stat_model_skl(model):
     """
@@ -456,22 +597,23 @@ def stat_model_skl(model):
     with open(model, "rb") as f:
         obj = pickle.load(f)
     return {"nb_estimators": get_nb_skl_objects(obj)}
-    
+
 
 def stat_model_onnx(model):
     """
     Computes statistics on the ONNX model.
     """
     import onnx
+
     gr = onnx.load(model)
     return {"nb_onnx_nodes": len(gr.graph.node)}
-    
+
 
 def make_report_backend(folder, as_df=False):
     """
     Looks into a folder for dumped files after
     the unit tests.
-    
+
     :param folder: dump folder, it should contain files *.bench*
     :param as_df: returns a dataframe instread of a list of dictionary
     :return: time execution
@@ -479,6 +621,7 @@ def make_report_backend(folder, as_df=False):
     import onnx
     import onnxruntime
     import cpuinfo
+
     res = {}
     benched = 0
     files = os.listdir(folder)
@@ -488,7 +631,7 @@ def make_report_backend(folder, as_df=False):
             if model not in res:
                 res[model] = {}
             res[model]["_tested"] = True
-        elif '.backend.' in name:
+        elif ".backend." in name:
             bk = name.split(".backend.")[-1].split(".")[0]
             model = name.split(".")[0]
             if model not in res:
@@ -502,7 +645,7 @@ def make_report_backend(folder, as_df=False):
             error = content.split("\n")[0].strip("\n\r ")
             if model not in res:
                 res[model] = {}
-            res[model]['stderr'] = error
+            res[model]["stderr"] = error
         elif name.endswith(".model.pkl"):
             model = name.split(".")[0]
             if model not in res:
@@ -516,19 +659,19 @@ def make_report_backend(folder, as_df=False):
         elif name.endswith(".bench"):
             model = name.split(".")[0]
             fullname = os.path.join(folder, name)
-            df = pandas.read_csv(fullname, sep=',')
+            df = pandas.read_csv(fullname, sep=",")
             if model not in res:
                 res[model] = {}
             for index, row in df.iterrows():
-                name = row['name']
-                ave = row['average']
-                std = row['deviation']
-                size = row['input_size']
-                res[model]['{0}_time'.format(name)] = ave
-                res[model]['{0}_std'.format(name)] = std
-                res[model]['input_size'] = size
+                name = row["name"]
+                ave = row["average"]
+                std = row["deviation"]
+                size = row["input_size"]
+                res[model]["{0}_time".format(name)] = ave
+                res[model]["{0}_std".format(name)] = std
+                res[model]["input_size"] = size
                 benched += 1
-    
+
     if benched == 0:
         raise RuntimeError("No benchmark files in '{0}', found:\n{1}".format(
             folder, "\n".join(files)))
@@ -536,32 +679,33 @@ def make_report_backend(folder, as_df=False):
     def dict_update(d, u):
         d.update(u)
         return d
-    
+
     aslist = [dict_update(dict(_model=k), v) for k, v in res.items()]
-    
-    if as_df:            
-        from pandas import DataFrame        
+
+    if as_df:
+        from pandas import DataFrame
+
         df = DataFrame(aslist).sort_values(["_model"])
         df["numpy-version"] = numpy.__version__
         df["onnx-version"] = onnx.__version__
         df["onnxruntime-version"] = onnxruntime.__version__
         cols = list(df.columns)
-        if 'stderr' in cols:
-            ind = cols.index('stderr')
+        if "stderr" in cols:
+            ind = cols.index("stderr")
             del cols[ind]
-            cols += ['stderr']
+            cols += ["stderr"]
             df = df[cols]
         for col in ["onnxrt_time", "original_time"]:
-            if col not in df.columns:        
+            if col not in df.columns:
                 raise RuntimeError("Column '{0}' is missing from {1}".format(
-                    col, ', '.join(df.columns)))
+                    col, ", ".join(df.columns)))
         df["ratio"] = df["onnxrt_time"] / df["original_time"]
         df["ratio_nodes"] = df["nb_onnx_nodes"] / df["nb_estimators"]
         df["CPU"] = platform.processor()
-        df["CPUI"] = cpuinfo.get_cpu_info()['brand']
+        df["CPUI"] = cpuinfo.get_cpu_info()["brand"]
         return df
     else:
-        cpu = cpuinfo.get_cpu_info()['brand']
+        cpu = cpuinfo.get_cpu_info()["brand"]
         proc = platform.processor()
         for row in aslist:
             try:
@@ -570,7 +714,8 @@ def make_report_backend(folder, as_df=False):
                 # execution failed
                 pass
             try:
-                row["ratio_nodes"] = row["nb_onnx_nodes"] / row["nb_estimators"]
+                row["ratio_nodes"] = (row["nb_onnx_nodes"] /
+                                      row["nb_estimators"])
             except KeyError:
                 # execution failed
                 pass

--- a/tests/test_utils/utils_backend.py
+++ b/tests/test_utils/utils_backend.py
@@ -5,7 +5,7 @@ import os
 import sys
 import glob
 import pickle
-from distutils.version import StrictVersion
+from distutils.version import StrictVersion  # noqa
 import numpy
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
@@ -22,7 +22,7 @@ class OnnxRuntimeAssertionError(AssertionError):
     Expected failure.
     """
     pass
-    
+
 
 def evaluate_condition(backend, condition):
     """
@@ -30,11 +30,12 @@ def evaluate_condition(backend, condition):
     ``StrictVersion(onnxruntime.__version__) <= StrictVersion('0.1.3')``
     """
     if backend == "onnxruntime":
-        import onnxruntime
-        import onnx
+        import onnxruntime  # noqa
+        import onnx  # noqa
         return eval(condition)
     else:
-        raise NotImplementedError("Not implemented for backend '{0}'".format(backend))
+        raise NotImplementedError(
+            "Not implemented for backend '{0}'".format(backend))
 
 
 def is_backend_enabled(backend):
@@ -43,21 +44,27 @@ def is_backend_enabled(backend):
     """
     if backend == "onnxruntime":
         try:
-            import onnxruntime
+            import onnxruntime  # noqa
             return True
         except ImportError:
             return False
     else:
-        raise NotImplementedError("Not implemented for backend '{0}'".format(backend))
+        raise NotImplementedError(
+            "Not implemented for backend '{0}'".format(backend))
 
 
-def compare_backend(backend, test, decimal=5, options=None, verbose=False, context=None,
+def compare_backend(backend,
+                    test,
+                    decimal=5,
+                    options=None,
+                    verbose=False,
+                    context=None,
                     comparable_outputs=None):
     """
     The function compares the expected output (computed with
     the model before being converted to ONNX) and the ONNX output
     produced with module *onnxruntime*.
-    
+
     :param backend: backend to use to run the comparison,
         only *onnxruntime* is currently supported
     :param test: dictionary with the following keys:
@@ -70,7 +77,7 @@ def compare_backend(backend, test, decimal=5, options=None, verbose=False, conte
     :param comparable_outputs: compare only these outputs
     :param verbose: in case of error, the function may print
         more information on the standard output
-    
+
     The function does not return anything but raises an error
     if the comparison failed.
     :return: tuple (output, lambda function to call onnx predictions)
@@ -78,9 +85,12 @@ def compare_backend(backend, test, decimal=5, options=None, verbose=False, conte
     if backend == "onnxruntime":
         if sys.version_info[0] == 2:
             # onnxruntime is not available on Python 2.
-            return            
+            return
         from .utils_backend_onnxruntime import compare_runtime
-        return compare_runtime(test, decimal, options=options, verbose=verbose,
+        return compare_runtime(test,
+                               decimal,
+                               options=options,
+                               verbose=verbose,
                                comparable_outputs=comparable_outputs)
     else:
         raise ValueError("Does not support backend '{0}'.".format(backend))
@@ -93,11 +103,12 @@ def search_converted_models(root=None):
     *dump_data_and_model*.
     """
     if root is None:
-        root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "__dump_data"))
+        root = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "__dump_data"))
         root = os.path.normpath(root)
     if not os.path.exists(root):
         raise FileNotFoundError("Unable to find '{0}'.".format(root))
-    
+
     founds = glob.iglob("{0}/**/*.model.onnx".format(root), recursive=True)
     keep = []
     for found in founds:
@@ -120,7 +131,7 @@ def search_converted_models(root=None):
                 keep.append((basename, res))
     keep.sort()
     return [_[1] for _ in keep]
-    
+
 
 def load_data_and_model(items_as_dict, **context):
     """
@@ -140,7 +151,8 @@ def load_data_and_model(items_as_dict, **context):
                         if '.model.' in v:
                             continue
                         else:
-                            raise ImportError("Unable to load '{0}' due to {1}".format(v, e))
+                            raise ImportError(
+                                "Unable to load '{0}' due to {1}".format(v, e))
                     res[k] = bin
             elif os.path.splitext(v)[-1] == ".keras":
                 import keras.models
@@ -156,7 +168,7 @@ def extract_options(name):
     """
     Extracts comparison option from filename.
     As example, ``Binarizer-SkipDim1`` means
-    options *SkipDim1* is enabled. 
+    options *SkipDim1* is enabled.
     ``(1, 2)`` and ``(2,)`` are considered equal.
     Available options: see :func:`dump_data_and_model`.
     """
@@ -193,27 +205,36 @@ def compare_outputs(expected, output, verbose=False, **kwargs):
         kwargs["decimal"] = min(kwargs["decimal"], 3)
     if Dec2:
         kwargs["decimal"] = min(kwargs["decimal"], 2)
-    if isinstance(expected, numpy.ndarray) and isinstance(output, numpy.ndarray):
+    if isinstance(expected, numpy.ndarray) and isinstance(
+            output, numpy.ndarray):
         if SkipDim1:
-            # Arrays like (2, 1, 2, 3) becomes (2, 2, 3) as one dimension is useless.
-            expected = expected.reshape(tuple([d for d in expected.shape if d > 1]))
-            output = output.reshape(tuple([d for d in expected.shape if d > 1]))
+            # Arrays like (2, 1, 2, 3) becomes (2, 2, 3)
+            # as one dimension is useless.
+            expected = expected.reshape(
+                tuple([d for d in expected.shape if d > 1]))
+            output = output.reshape(tuple([d for d in expected.shape
+                                           if d > 1]))
         if NoProb:
             # One vector is (N,) with scores, negative for class 0
             # positive for class 1
             # The other vector is (N, 2) score in two columns.
-            if len(output.shape) == 2 and output.shape[1] == 2 and len(expected.shape) == 1:
+            if len(output.shape) == 2 and output.shape[1] == 2 and len(
+                    expected.shape) == 1:
                 output = output[:, 1]
             elif len(output.shape) == 1 and len(expected.shape) == 1:
                 pass
             elif len(expected.shape) == 1 and len(output.shape) == 2 and \
-                    expected.shape[0] == output.shape[0] and output.shape[1] == 1:
+                    expected.shape[0] == output.shape[0] and \
+                    output.shape[1] == 1:
                 output = output[:, 0]
             elif expected.shape != output.shape:
-                raise NotImplementedError("No good shape: {0} != {1}".format(expected.shape, output.shape))
-        if len(expected.shape) == 1 and len(output.shape) == 2 and output.shape[1] == 1:
+                raise NotImplementedError("No good shape: {0} != {1}".format(
+                    expected.shape, output.shape))
+        if len(expected.shape) == 1 and len(
+                output.shape) == 2 and output.shape[1] == 1:
             output = output.ravel()
-        if len(output.shape) == 3 and output.shape[0] == 1 and len(expected.shape) == 2:
+        if len(output.shape) == 3 and output.shape[0] == 1 and len(
+                expected.shape) == 2:
             output = output.reshape(output.shape[1:])
         if expected.dtype in (numpy.str, numpy.dtype("<U1")):
             try:
@@ -226,27 +247,41 @@ def compare_outputs(expected, output, verbose=False, **kwargs):
                     return OnnxRuntimeAssertionError(str(e))
         else:
             try:
-                assert_array_almost_equal(expected, output, verbose=verbose, **kwargs)
+                assert_array_almost_equal(expected,
+                                          output,
+                                          verbose=verbose,
+                                          **kwargs)
             except Exception as e:
-                longer = "\n--EXPECTED--\n{0}\n--OUTPUT--\n{1}".format(expected, output) if verbose else ""
+                longer = "\n--EXPECTED--\n{0}\n--OUTPUT--\n{1}".format(
+                    expected, output) if verbose else ""
                 expected_ = numpy.asarray(expected).ravel()
                 output_ = numpy.asarray(output).ravel()
                 if len(expected_) == len(output_):
                     if numpy.issubdtype(expected_.dtype, numpy.floating):
                         diff = numpy.abs(expected_ - output_).max()
                     else:
-                        diff = max((1 if ci != cj else 0) for ci, cj in zip(expected_, output_))
+                        diff = max((1 if ci != cj else 0)
+                                   for ci, cj in zip(expected_, output_))
                     if diff == 0:
                         return None
                 elif Mism:
-                    return ExpectedAssertionError("dimension mismatch={0}, {1}\n{2}{3}".format(expected.shape, output.shape, e, longer))
+                    return ExpectedAssertionError(
+                        "dimension mismatch={0}, {1}\n{2}{3}".format(
+                            expected.shape, output.shape, e, longer))
                 else:
-                    return OnnxRuntimeAssertionError("dimension mismatch={0}, {1}\n{2}{3}".format(expected.shape, output.shape, e, longer))
+                    return OnnxRuntimeAssertionError(
+                        "dimension mismatch={0}, {1}\n{2}{3}".format(
+                            expected.shape, output.shape, e, longer))
                 if Disc:
                     # Bug to be fixed later.
-                    return ExpectedAssertionError("max-diff={0}\n--expected--output--\n{1}{2}".format(diff, e, longer))
+                    return ExpectedAssertionError(
+                        "max-diff={0}\n--expected--output--\n{1}{2}".format(
+                            diff, e, longer))
                 else:
-                    return OnnxRuntimeAssertionError("max-diff={0}\n--expected--output--\n{1}{2}".format(diff, e, longer))
+                    return OnnxRuntimeAssertionError(
+                        "max-diff={0}\n--expected--output--\n{1}{2}".format(
+                            diff, e, longer))
     else:
-        return OnnxRuntimeAssertionError("Unexpected types {0} != {1}".format(type(expected), type(output)))
+        return OnnxRuntimeAssertionError("Unexpected types {0} != {1}".format(
+            type(expected), type(output)))
     return None


### PR DESCRIPTION
There are many flake8 errors in tests package. So I will separately fix these lint errors.

```console
$ flake8 tests/ | wc -l
     853
```

In this PR, I fix lint errors of the files under the `tests/test_utils` directory.

*Before:*

```console
$ flake8 tests/test_utils/ | wc -l
     218
```

*After:*

```
$ flake8 tests/test_utils/
$ 
```

I use `noqa` comments to ignore following flake8 errors:

* https://lintlyci.github.io/Flake8Rules/rules/E731.html
* https://lintlyci.github.io/Flake8Rules/rules/F401.html