### PR TITLE
Run flake8 in linux-conda-ci

### DIFF
--- a/.azure-pipelines/linux-conda-CI.yml
+++ b/.azure-pipelines/linux-conda-CI.yml
@@ -71,6 +71,10 @@ jobs:
     displayName: 'install flake8'
 
   - script: |
+      flake8 skl2onnx
+    displayName: 'flake8'
+
+  - script: |
       pip install numpy$(numpy.version)
     displayName: 'install numpy'
 


### PR DESCRIPTION
Currently, flake8 is installed but not executed.