### PR TITLE
Test skl2onnx with onnxruntime nightly build

### DIFF
--- a/.azure-pipelines/linux-CI-nightly.yml
+++ b/.azure-pipelines/linux-CI-nightly.yml
@@ -1,0 +1,99 @@
+# Python package
+# Create and test a Python package on multiple Python versions.
+# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+trigger:
+- master
+
+jobs:
+
+- job: 'Test'
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  strategy:
+    matrix:
+      Py36-Onnx141:
+        python.version: '3.6'
+        numpy.version: '==1.16.2'
+        onnx.version: '==1.4.1'
+        onnxrt.version: '-i https://test.pypi.org/simple/ ort-nightly'
+        sklearn.version: '==0.20.3'
+    maxParallel: 3
+
+  steps:
+  - task: CondaEnvironment@1
+    inputs:
+      createCustomEnvironment: true
+      environmentName: 'py$(python.version)'
+      packageSpecs: 'python=$(python.version)'
+
+  - script: |
+      conda config --set always_yes yes --set changeps1 no
+      conda install -c conda-forge numpy$(numpy.version)
+      conda install protobuf
+      python -m pip install --upgrade pip
+    displayName: 'Install environment'
+
+  - script: |
+      pip install numpy$(numpy.version)
+    displayName: 'install numpy'
+
+  - script: |
+      pip install scikit-learn$(sklearn.version)
+    displayName: 'install scikit-learn'
+
+  - script: |
+      pip install onnx$(onnx.version)
+    displayName: 'install onnx'
+
+  - script: |
+      pip install $(onnxrt.version)
+    displayName: 'install onnxruntime'
+
+  - script: |
+      pip install -r requirements.txt
+      pip install -r requirements-dev.txt
+      pip install pytest
+    displayName: 'install requirements'
+
+  - script: |
+      pip install -e .
+    displayName: 'install'
+
+  - script: |
+      echo "---------------"
+      pip show numpy
+      echo "---------------"
+      pip show onnx
+      echo "---------------"
+      pip show onnxruntime
+      echo "---------------"
+      pip show onnxconverter-common
+      echo "---------------"
+      pip show scikit-learn
+      echo "---------------"
+    displayName: 'version'
+
+  - script: |
+      pytest tests --basetemp=temp --doctest-modules --junitxml=junit/test-results.xml
+    displayName: 'pytest'
+
+  - script: |
+      pip install onnxmltools openpyxl
+      coverage run --include=skl2onnx/** tests/benchmark.py
+      coverage report -m
+      coverage html
+    displayName: 'coverage'
+
+  - script: |
+      python tests/benchmark.py
+    displayName: 'benchmark'
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/test-results.xml'
+      testCoverageFiles: 'htmlcov/**'
+      testBenchmarkFiles: 'TESTDUMP/*.xlsx'
+      testRunTitle: 'Python $(python.version)'
+    condition: succeededOrFailed()

--- a/.azure-pipelines/win32-CI-nightly.yml
+++ b/.azure-pipelines/win32-CI-nightly.yml
@@ -1,0 +1,93 @@
+# Python package
+# Create and test a Python package on multiple Python versions.
+# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+trigger:
+- master
+
+jobs:
+
+- job: 'Test'
+  pool:
+    vmImage: 'vs2017-win2016'
+  strategy:
+    matrix:
+      Py36-Onnx141-nightlyRT-Npy1154:
+        python.version: '3.6.7'
+        onnx.version: 'onnx==1.4.1'
+        numpy.version: 'numpy==1.16.2'
+        scipy.version: 'scipy'
+        onnxrt.version: '-i https://test.pypi.org/simple/ ort-nightly'
+    maxParallel: 3
+
+  steps:
+  - task: CondaEnvironment@1
+    inputs:
+      createCustomEnvironment: false
+      packageSpecs: 'python=$(python.version)'
+
+  - script: |
+      conda install -y -c anaconda scikit-learn
+    displayName: 'Install numpy mkl scipy pandas sklearn'
+
+  - script: |
+      conda install -y -c conda-forge protobuf
+      python -m pip install --upgrade pip
+      pip install $(numpy.version)
+      pip install $(scipy.version)
+      pip install $(onnx.version)
+    displayName: 'Install numpy, scipy, onnx'
+
+  - script: |
+      pip install flake8
+    displayName: 'install flake8'
+
+  - script: |
+      flake8 skl2onnx tests
+    displayName: 'flake8'
+
+  - script: |
+      pip install -r requirements.txt
+      pip install -r requirements-dev.txt
+      pip install pytest
+    displayName: 'install requirements'
+
+  - script: |
+      pip install $(onnxrt.version)
+    displayName: 'install onnxruntime'
+
+  - script: |
+      pip install -e .
+    displayName: 'install skl2onnx'
+
+  - script: |
+      python -c "import numpy;print('numpy:',numpy.__version__)"
+      python -c "import scipy;print('scipy:',scipy.__version__)"
+      python -c "import onnx;print('onnx:',onnx.__version__)"
+      python -c "import onnxconverter_common;print('onnxconverter-common:',onnxconverter_common.__version__)"
+      python -c "import onnxruntime;print('onnxruntime:',onnxruntime.__version__)"
+    displayName: 'version'
+
+  - script: |
+      pytest tests --basetemp=temp --doctest-modules --junitxml=junit/test-results.xml
+    displayName: 'pytest'
+
+  - script: |
+      pip install onnxmltools openpyxl
+      coverage run --include=skl2onnx/** tests/benchmark.py
+      coverage report -m
+      coverage html
+    displayName: 'coverage'
+
+  - script: |
+      python tests/benchmark.py
+    displayName: 'benchmark'
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/test-results.xml'
+      testCoverageFiles: 'htmlcov/**'
+      testBenchmarkFiles: 'TESTDUMP/*.xlsx'
+      testRunTitle: 'Python $(python.version)'
+    condition: succeededOrFailed()

--- a/.azure-pipelines/win32-CI-nightly.yml
+++ b/.azure-pipelines/win32-CI-nightly.yml
@@ -40,14 +40,6 @@ jobs:
     displayName: 'Install numpy, scipy, onnx'
 
   - script: |
-      pip install flake8
-    displayName: 'install flake8'
-
-  - script: |
-      flake8 skl2onnx tests
-    displayName: 'flake8'
-
-  - script: |
       pip install -r requirements.txt
       pip install -r requirements-dev.txt
       pip install pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 six
-numpy
+numpy>=1.15
 protobuf
-onnx
+onnx>=1.2.1
 scikit-learn>=0.19
 onnxconverter-common>=1.4.0

--- a/tests/test_SklearnTfidfTransformerConverterSparse.py
+++ b/tests/test_SklearnTfidfTransformerConverterSparse.py
@@ -48,7 +48,7 @@ class TestSklearnTfidfVectorizerSparse(unittest.TestCase):
             basename="SklearnPipelineTfidfTransformer",
             # Operator mul is not implemented in onnxruntime
             allow_failure="StrictVersion(onnx.__version__)"
-                          " <= StrictVersion('1.4.1')",
+                          " <= StrictVersion('1.5')",
         )
 
 

--- a/tests/test_custom_transformer.py
+++ b/tests/test_custom_transformer.py
@@ -166,7 +166,7 @@ class TestOtherLibrariesInPipeline(unittest.TestCase):
             model_onnx,
             basename="CustomTransformerTSNEkNN-OneOffArray",
             allow_failure="StrictVersion(onnx.__version__) "
-                          "== StrictVersion('1.4.1')",
+                          "<= StrictVersion('1.5')",
         )
 
         trace_line = []

--- a/tests/test_custom_transformer.py
+++ b/tests/test_custom_transformer.py
@@ -190,7 +190,7 @@ class TestOtherLibrariesInPipeline(unittest.TestCase):
             model_onnx,
             basename="CustomTransformerTSNEkNNCustomParser-OneOffArray",
             allow_failure="StrictVersion(onnx.__version__) "
-            "== StrictVersion('1.4.1')",
+            "<= StrictVersion('1.5')",
         )
 
         update_registered_parser(PredictableTSNE, my_parser)


### PR DESCRIPTION
Created nightly build pipeline as two separate YAML files, like in onnxmltools. This is to ensure it doesn't impact every CI PR build and can be run independently.

(This is to replace closed PR #109)