### PR TITLE
Install onnxconverter-common from source in CI pipelines

### DIFF
--- a/.azure-pipelines/linux-CI-nightly.yml
+++ b/.azure-pipelines/linux-CI-nightly.yml
@@ -57,6 +57,10 @@ jobs:
 
   - script: |
       pip install -r requirements.txt
+      git clone https://github.com/microsoft/onnxconverter-common
+      cd onnxconverter-common
+      pip install -e .
+      cd ..
       pip install -r requirements-dev.txt
       pip install pytest
     displayName: 'install requirements'

--- a/.azure-pipelines/linux-conda-CI.yml
+++ b/.azure-pipelines/linux-conda-CI.yml
@@ -106,6 +106,10 @@ jobs:
 
   - script: |
       pip install -r requirements.txt
+      git clone https://github.com/microsoft/onnxconverter-common
+      cd onnxconverter-common
+      pip install -e .
+      cd ..
       pip install -r requirements-dev.txt
       pip install pytest
     displayName: 'install requirements'

--- a/.azure-pipelines/win32-CI-nightly.yml
+++ b/.azure-pipelines/win32-CI-nightly.yml
@@ -37,6 +37,10 @@ jobs:
 
   - script: |
       pip install -r requirements.txt
+      git clone https://github.com/microsoft/onnxconverter-common
+      cd onnxconverter-common
+      pip install -e .
+      cd ..
       pip install -r requirements-dev.txt
       pip install pytest
     displayName: 'install requirements'

--- a/.azure-pipelines/win32-conda-CI.yml
+++ b/.azure-pipelines/win32-conda-CI.yml
@@ -65,6 +65,10 @@ jobs:
 
   - script: |
       pip install -r requirements.txt
+      git clone https://github.com/microsoft/onnxconverter-common
+      cd onnxconverter-common
+      pip install -e .
+      cd ..
       pip install pytest
     displayName: 'install requirements'
 


### PR DESCRIPTION
Reference: https://github.com/onnx/onnxmltools/pull/320

Install onnxconverter-common from github master so new changes will persist in the CI without having to publish a new package for each change