### PR TITLE
Casts numerical input into int64 for OneHotEncoder (fixes #320, #321), changes parsing for ColumnTransformer

### DIFF
--- a/skl2onnx/_parse.py
+++ b/skl2onnx/_parse.py
@@ -254,7 +254,6 @@ def _parse_sklearn_column_transformer(scope, model, inputs,
         if merged_cols:
             # Many ONNX operators expect one input vector,
             # the default behaviour is to merge columns.
-            print("+++", op)
             ty = transform_inputs[0].type.__class__([None, None])
 
             conc_op = scope.declare_local_operator('SklearnConcat')

--- a/skl2onnx/operator_converters/one_hot_encoder.py
+++ b/skl2onnx/operator_converters/one_hot_encoder.py
@@ -6,84 +6,109 @@
 
 import numpy as np
 from ..common._apply_operation import apply_cast, apply_concat, apply_reshape
-from ..common.data_types import Int64TensorType, StringTensorType
+from ..common.data_types import (
+    Int64TensorType, StringTensorType, Int32TensorType,
+    FloatTensorType, DoubleTensorType
+)
 from ..common._registration import register_converter
 from ..proto import onnx_proto
 
 
 def convert_sklearn_one_hot_encoder(scope, operator, container):
     ohe_op = operator.raw_operator
-    result, categories_len = [], 0
-    concatenated_input_name = operator.inputs[0].full_name
-    concat_result_name = scope.get_unique_variable_name('concat_result')
 
     if len(operator.inputs) > 1:
-        concatenated_input_name = scope.get_unique_variable_name(
-            'concatenated_input')
-        if all(isinstance(inp.type, type(operator.inputs[0].type))
-               for inp in operator.inputs):
-            input_names = list(map(lambda x: x.full_name, operator.inputs))
-        else:
-            input_names = []
-            for inp in operator.inputs:
-                if isinstance(inp.type, Int64TensorType):
-                    input_names.append(scope.get_unique_variable_name(
-                        'cast_input'))
-                    apply_cast(scope, inp.full_name, input_names[-1],
-                               container, to=onnx_proto.TensorProto.STRING)
-                elif isinstance(inp.type, StringTensorType):
-                    input_names.append(inp.full_name)
-                else:
-                    raise NotImplementedError(
-                        "{} input datatype not yet supported. "
-                        "You may raise an issue at "
-                        "https://github.com/onnx/sklearn-onnx/issues"
-                        "".format(type(inp.type)))
+        all_shapes = [inp.type.shape[1] for inp in operator.inputs]
+        if any(map(lambda x: not isinstance(x, int) or x < 1, all_shapes)):
+            raise RuntimeError(
+                "Shapes must be known when OneHotEncoder is converted. "
+                "There are {} inputs with the following number of columns "
+                "{}.".format(len(operator.inputs), all_shapes))
+        total = sum(all_shapes)
+        if total != len(ohe_op.categories_):
+            raise RuntimeError(
+                "Mismatch between the number of sets of categories {} and "
+                "the total number of inputs columns {}.".format(
+                    len(ohe_op.categories_), total))
 
-        apply_concat(scope, input_names,
-                     concatenated_input_name, container, axis=1)
+        enum_cats = []
+        index_inputs = 0
 
-    for index, categories in enumerate(ohe_op.categories_):
+        for index, cats in enumerate(ohe_op.categories_):
+
+            while sum(all_shapes[:index_inputs+1]) <= index:
+                index_inputs += 1
+            index_in_input = index - sum(all_shapes[:index_inputs])
+
+            inp = operator.inputs[index_inputs]
+            if not isinstance(
+                    inp.type,
+                    (Int64TensorType, StringTensorType, Int32TensorType,
+                     FloatTensorType, DoubleTensorType)):
+                raise NotImplementedError(
+                    "{} input datatype not yet supported. "
+                    "You may raise an issue at "
+                    "https://github.com/onnx/sklearn-onnx/issues"
+                    "".format(type(inp.type)))
+
+            if all_shapes[index_inputs] == 1:
+                assert index_in_input == 0
+                afeat = False
+            else:
+                afeat = True
+            enum_cats.append(
+                (afeat, index_in_input, inp.full_name, cats, inp.type))
+    else:
+        inp = operator.inputs[0]
+        enum_cats = [(True, i, inp.full_name, cats, inp.type)
+                     for i, cats in enumerate(ohe_op.categories_)]
+
+    result, categories_len = [], 0
+    for index, enum_c in enumerate(enum_cats):
+        afeat, index_in, name, categories, inp_type = enum_c
+        if afeat:
+            index_name = scope.get_unique_variable_name(
+                name + str(index_in))
+            container.add_initializer(
+                index_name, onnx_proto.TensorProto.INT64, [], [index_in])
+            out_name = scope.get_unique_variable_name(
+                name + str(index_in))
+            container.add_node(
+                'ArrayFeatureExtractor', [name, index_name],
+                out_name, op_domain='ai.onnx.ml',
+                name=scope.get_unique_operator_name('ArrayFeatureExtractor'))
+            name = out_name
+
         attrs = {'name': scope.get_unique_operator_name('OneHotEncoder')}
         attrs['zeros'] = 1 if ohe_op.handle_unknown == 'ignore' else 0
         if hasattr(ohe_op, 'drop_idx_') and ohe_op.drop_idx_ is not None:
             categories = (categories[np.arange(len(categories)) !=
                                      ohe_op.drop_idx_[index]])
-        if len(categories) > 0:
-            if (np.issubdtype(categories.dtype, np.floating)
-                    or np.issubdtype(categories.dtype, np.signedinteger)):
-                attrs['cats_int64s'] = categories.astype(np.int64)
-            else:
-                attrs['cats_strings'] = np.array(
-                    [str(s).encode('utf-8') for s in categories])
 
-            index_name = scope.get_unique_variable_name('index')
-            feature_column_name = scope.get_unique_variable_name(
-                'feature_column')
-            result.append(scope.get_unique_variable_name('ohe_output'))
+        if isinstance(inp_type, (Int64TensorType, Int32TensorType)):
+            attrs['cats_int64s'] = categories.astype(np.int64)
+        else:
+            attrs['cats_strings'] = np.array(
+                [str(s).encode('utf-8') for s in categories])
 
-            container.add_initializer(
-                index_name, onnx_proto.TensorProto.INT64, [], [index])
+        ohe_output = scope.get_unique_variable_name(name + 'out')
+        result.append(ohe_output)
 
-            container.add_node(
-                'ArrayFeatureExtractor',
-                [concatenated_input_name, index_name],
-                feature_column_name, op_domain='ai.onnx.ml',
-                name=scope.get_unique_operator_name('ArrayFeatureExtractor'))
+        if 'cats_int64s' in attrs:
+            # Let's cast this input in int64.
+            cast_feature = scope.get_unique_variable_name(name + 'cast')
+            apply_cast(scope, name, cast_feature, container,
+                       to=onnx_proto.TensorProto.INT64)
+            name = cast_feature
 
-            if 'cats_int64s' in attrs:
-                # Let's cast this input in int64.
-                cast_feature = scope.get_unique_variable_name('castohe')
-                apply_cast(scope, feature_column_name, cast_feature,
-                           container, to=onnx_proto.TensorProto.INT64)
-                feature_column_name = cast_feature
+        container.add_node('OneHotEncoder', name,
+                           ohe_output, op_domain='ai.onnx.ml',
+                           **attrs)
 
-            container.add_node('OneHotEncoder', feature_column_name,
-                               result[-1], op_domain='ai.onnx.ml', **attrs)
-            categories_len += len(categories)
+        categories_len += len(categories)
 
-    apply_concat(scope, result,
-                 concat_result_name, container, axis=2)
+    concat_result_name = scope.get_unique_variable_name('concat_result')
+    apply_concat(scope, result, concat_result_name, container, axis=2)
 
     reshape_input = concat_result_name
     if np.issubdtype(ohe_op.dtype, np.signedinteger):

--- a/skl2onnx/operator_converters/one_hot_encoder.py
+++ b/skl2onnx/operator_converters/one_hot_encoder.py
@@ -35,7 +35,6 @@ def convert_sklearn_one_hot_encoder(scope, operator, container):
         index_inputs = 0
 
         for index, cats in enumerate(ohe_op.categories_):
-
             while sum(all_shapes[:index_inputs+1]) <= index:
                 index_inputs += 1
             index_in_input = index - sum(all_shapes[:index_inputs])
@@ -66,6 +65,8 @@ def convert_sklearn_one_hot_encoder(scope, operator, container):
     result, categories_len = [], 0
     for index, enum_c in enumerate(enum_cats):
         afeat, index_in, name, categories, inp_type = enum_c
+        if len(categories) == 0:
+            continue
         if afeat:
             index_name = scope.get_unique_variable_name(
                 name + str(index_in))

--- a/skl2onnx/operator_converters/one_hot_encoder.py
+++ b/skl2onnx/operator_converters/one_hot_encoder.py
@@ -15,6 +15,11 @@ from ..proto import onnx_proto
 
 
 def convert_sklearn_one_hot_encoder(scope, operator, container):
+    """
+    Converts *OneHotEncoder* into ONNX.
+    It supports multiple inputs of types
+    string or int64.
+    """
     ohe_op = operator.raw_operator
 
     if len(operator.inputs) > 1:

--- a/skl2onnx/shape_calculators/concat.py
+++ b/skl2onnx/shape_calculators/concat.py
@@ -35,10 +35,12 @@ def calculate_sklearn_concat(operator):
             seen_types.append(nt)
         elif nt != seen_types[0]:
             inps = "\n".join(str(v) for v in operator.inputs)
-            raise RuntimeError("Columns must have the same type. "
-                               "C++ backends do not support mixed types. "
-                               "Inputs:\n"
-                               + inps)
+            outs = "\n".join(str(v) for v in operator.outputs)
+            raise RuntimeError(
+                "Columns must have the same type. "
+                "C++ backends do not support mixed types.\n"
+                "Inputs:\n{}\nOutputs:\n{}".format(
+                    inps, outs))
     operator.outputs[0].type.shape = [N, C]
 
 

--- a/tests/test_onnx_helper.py
+++ b/tests/test_onnx_helper.py
@@ -59,8 +59,10 @@ class TestOnnxHelper(unittest.TestCase):
         reason="OneHotEncoder did not have categories_ before 0.20",
     )
     def test_onnx_helper_load_save_init(self):
-        model = make_pipeline(Binarizer(), OneHotEncoder(sparse=False),
-                              StandardScaler())
+        model = make_pipeline(
+            Binarizer(),
+            OneHotEncoder(sparse=False, handle_unknown='ignore'),
+            StandardScaler())
         X = numpy.array([[0.1, 1.1], [0.2, 2.2], [0.4, 2.2], [0.2, 2.4]])
         model.fit(X)
         model_onnx = convert_sklearn(model, "pipe3",

--- a/tests/test_sklearn_one_hot_encoder_converter.py
+++ b/tests/test_sklearn_one_hot_encoder_converter.py
@@ -116,17 +116,12 @@ class TestSklearnOneHotEncoderConverter(unittest.TestCase):
             ("input1", StringTensorType([None, 2])),
             ("input2", Int64TensorType([None, 1])),
         ]
-        model_onnx = convert_sklearn(model,
-                                     "one-hot encoder",
-                                     inputs)
+        model_onnx = convert_sklearn(
+            model, "one-hot encoder", inputs)
         self.assertTrue(model_onnx is not None)
         dump_data_and_model(
-            test,
-            model,
-            model_onnx,
-            basename="SklearnOneHotEncoderMixedStringIntDrop",
-            verbose=False,
-        )
+            test, model, model_onnx, verbose=False,
+            basename="SklearnOneHotEncoderMixedStringIntDrop")
 
     @unittest.skipIf(
         not one_hot_encoder_supports_string(),

--- a/tests/test_sklearn_one_hot_encoder_converter.py
+++ b/tests/test_sklearn_one_hot_encoder_converter.py
@@ -29,6 +29,8 @@ def one_hot_encoder_supports_drop():
 
 
 class TestSklearnOneHotEncoderConverter(unittest.TestCase):
+    @unittest.skipIf(StrictVersion(ort_version) <= StrictVersion("0.4.0"),
+                     reason="issues with shapes")
     @unittest.skipIf(
         not one_hot_encoder_supports_string(),
         reason="OneHotEncoder did not have categories_ before 0.20",
@@ -51,6 +53,8 @@ class TestSklearnOneHotEncoderConverter(unittest.TestCase):
             basename="SklearnOneHotEncoderInt64-SkipDim1",
         )
 
+    @unittest.skipIf(StrictVersion(ort_version) <= StrictVersion("0.4.0"),
+                     reason="issues with shapes")
     @unittest.skipIf(
         not one_hot_encoder_supports_string(),
         reason="OneHotEncoder did not have categories_ before 0.20",
@@ -72,6 +76,8 @@ class TestSklearnOneHotEncoderConverter(unittest.TestCase):
             data, model, model_onnx,
             basename="SklearnOneHotEncoderInt32-SkipDim1")
 
+    @unittest.skipIf(StrictVersion(ort_version) <= StrictVersion("0.4.0"),
+                     reason="issues with shapes")
     @unittest.skipIf(
         not one_hot_encoder_supports_string(),
         reason="OneHotEncoder did not have categories_ before 0.20",
@@ -123,6 +129,8 @@ class TestSklearnOneHotEncoderConverter(unittest.TestCase):
             test, model, model_onnx, verbose=False,
             basename="SklearnOneHotEncoderMixedStringIntDrop")
 
+    @unittest.skipIf(StrictVersion(ort_version) <= StrictVersion("0.4.0"),
+                     reason="issues with shapes")
     @unittest.skipIf(
         not one_hot_encoder_supports_string(),
         reason="OneHotEncoder does not support strings in 0.19",
@@ -142,6 +150,8 @@ class TestSklearnOneHotEncoderConverter(unittest.TestCase):
             basename="SklearnOneHotEncoderOneStringCat",
         )
 
+    @unittest.skipIf(StrictVersion(ort_version) <= StrictVersion("0.4.0"),
+                     reason="issues with shapes")
     @unittest.skipIf(
         not one_hot_encoder_supports_string(),
         reason="OneHotEncoder does not support strings in 0.19",
@@ -187,6 +197,8 @@ class TestSklearnOneHotEncoderConverter(unittest.TestCase):
             basename="SklearnOneHotEncoderStringDropFirst",
         )
 
+    @unittest.skipIf(StrictVersion(ort_version) <= StrictVersion("0.4.0"),
+                     reason="issues with shapes")
     @unittest.skipIf(
         not one_hot_encoder_supports_string(),
         reason="OneHotEncoder does not support this in 0.19",
@@ -212,6 +224,8 @@ class TestSklearnOneHotEncoderConverter(unittest.TestCase):
             basename="SklearnOneHotEncoderCatSparse-SkipDim1",
         )
 
+    @unittest.skipIf(StrictVersion(ort_version) <= StrictVersion("0.4.0"),
+                     reason="issues with shapes")
     @unittest.skipIf(
         not one_hot_encoder_supports_string(),
         reason="OneHotEncoder does not support this in 0.19",
@@ -237,6 +251,8 @@ class TestSklearnOneHotEncoderConverter(unittest.TestCase):
             basename="SklearnOneHotEncoderCatDense-SkipDim1",
         )
 
+    @unittest.skipIf(StrictVersion(ort_version) <= StrictVersion("0.4.0"),
+                     reason="issues with shapes")
     @unittest.skipIf(
         not one_hot_encoder_supports_drop(),
         reason="OneHotEncoder does not support drop in scikit versions < 0.21",
@@ -269,6 +285,8 @@ class TestSklearnOneHotEncoderConverter(unittest.TestCase):
             verbose=False,
         )
 
+    @unittest.skipIf(StrictVersion(ort_version) <= StrictVersion("0.4.0"),
+                     reason="issues with shapes")
     @unittest.skipIf(
         not one_hot_encoder_supports_drop(),
         reason="OneHotEncoder does not support drop in scikit versions < 0.21",

--- a/tests/test_sklearn_pipeline.py
+++ b/tests/test_sklearn_pipeline.py
@@ -369,7 +369,7 @@ class TestSklearnPipeline(unittest.TestCase):
         sess = InferenceSession(model_onnx.SerializeToString())
         run = sess.run(None, inputs)
         got = run[-1]
-        assert_almost_equal(pred, got)
+        assert_almost_equal(pred, got, decimal=5)
 
     @unittest.skipIf(
         ColumnTransformer is None,


### PR DESCRIPTION
Onnx specifications is confusing about support of int32 as inputs. Attribute name for categories is cat_int64s and onnxruntime does not support int32 inputs.