### PR TITLE
Pin sklearn version to fix broken onnxmltools tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ numpy>=1.15
 scipy>=1.0
 protobuf
 onnx>=1.2.1
-scikit-learn>=0.19
+scikit-learn>=0.19,<0.22
 onnxconverter-common>=1.5.1


### PR DESCRIPTION
coremltools has not updated the breaking change to imputer in their libary for version 0.22 of sklearn.

As coremltools is an onnxmltools dependency, adding a max version pin for sklearn in requirements.txt temporarily.