### PR TITLE
Add function to upgrade opset

### DIFF
--- a/docs/examples/plot_custom_model.py
+++ b/docs/examples/plot_custom_model.py
@@ -53,8 +53,7 @@ from skl2onnx import update_registered_converter
 import os
 from onnx.tools.net_drawer import GetPydotGraph, GetOpNodeProducer
 import onnxruntime as rt
-from skl2onnx import convert_sklearn
-from skl2onnx._parse import get_model_alias
+from skl2onnx import convert_sklearn, get_model_alias
 from skl2onnx.common._registration import get_shape_calculator
 from skl2onnx.common.data_types import FloatTensorType
 from matplotlib import offsetbox

--- a/docs/examples/plot_custom_model.py
+++ b/docs/examples/plot_custom_model.py
@@ -54,7 +54,7 @@ import os
 from onnx.tools.net_drawer import GetPydotGraph, GetOpNodeProducer
 import onnxruntime as rt
 from skl2onnx import convert_sklearn
-from skl2onnx._parse import _get_sklearn_operator_name
+from skl2onnx._parse import get_model_alias
 from skl2onnx.common._registration import get_shape_calculator
 from skl2onnx.common.data_types import FloatTensorType
 from matplotlib import offsetbox
@@ -331,7 +331,7 @@ def predictable_tsne_converter(scope, operator, container):
     # we reuse existing converter and declare it as local
     # operator
     model = op.estimator_
-    alias = _get_sklearn_operator_name(type(model))
+    alias = get_model_alias(type(model))
     knn_op = scope.declare_local_operator(alias, model)
     knn_op.inputs = operator.inputs
 

--- a/skl2onnx/__init__.py
+++ b/skl2onnx/__init__.py
@@ -16,7 +16,9 @@ __model_version__ = 0
 
 
 from .convert import convert_sklearn, to_onnx, wrap_as_onnx_mixin # noqa
-from ._supported_operators import update_registered_converter # noqa
+from ._supported_operators import ( # noqa
+    update_registered_converter, get_model_alias
+)
 from ._parse import update_registered_parser # noqa
 
 

--- a/skl2onnx/_supported_operators.py
+++ b/skl2onnx/_supported_operators.py
@@ -368,5 +368,22 @@ def _get_sklearn_operator_name(model_type):
     return sklearn_operator_name_map[model_type]
 
 
+def get_model_alias(model_type):
+    """
+    Get alias model. Raise an exception if not found.
+
+    :param model_type:  A scikit-learn object (e.g., SGDClassifier
+                        and Binarizer)
+    :return: A string which stands for the type of the input model in
+             our conversion framework
+    """
+    res = _get_sklearn_operator_name(model_type)
+    if res is None:
+        raise RuntimeError("Unable to find alias for model '{}'. "
+                           "The converter is likely missing."
+                           "".format(type(model_type)))
+    return res
+
+
 # registered converters
 sklearn_operator_name_map = build_sklearn_operator_name_map()

--- a/skl2onnx/helpers/onnx_rare_helper.py
+++ b/skl2onnx/helpers/onnx_rare_helper.py
@@ -1,0 +1,85 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import onnx
+from ..proto.onnx_helper_modified import (
+    make_graph, make_model
+)
+from onnx.defs import get_all_schemas_with_history
+
+
+def _build_op_version():
+    res = {}
+    for schema in get_all_schemas_with_history():
+        dom = schema.domain
+        name = schema.name
+        vers = schema.since_version
+        if (dom, name) not in res:
+            res[dom, name] = set()
+        res[dom, name].add(vers)
+    op_versions = {}
+    for k, v in res.items():
+        op_versions[k] = list(sorted(v))
+    return op_versions
+
+
+def _check_possible_opset(versions, nodes, domain, old_opset, new_opset):
+    if old_opset >= new_opset:
+        raise RuntimeError("Condition new_opset > old_opset is not true.")
+    for node in nodes:
+        name = node.op_type
+        vers = versions.get((domain, name), None)
+        if vers is None:
+            # custom operator
+            continue
+        for v in vers:
+            if v > old_opset and v <= new_opset:
+                raise RuntimeError(
+                    "Operator '{}' (domain: '{}') was updated "
+                    "in opset {} in ]{}, {}]."
+                    "".format(name, domain, v, old_opset, new_opset))
+
+
+def upgrade_opset_number(model, new_opsets):
+    """
+    Upgrades the domain opsets. It checks if that's
+    possible. It means ONNX specifications do not
+    propose a new version of every operator between
+    the current opset and the new one.
+
+    :param model: *ONNX* model
+    :param new_opdets: integer or dictionary
+        ``{ domain: opset }``
+    :return: modified model
+    """
+    if isinstance(new_opsets, int):
+        new_opsets = {'': new_opsets}
+    graph = make_graph(model.graph.node, model.graph.name, model.graph.input,
+                       model.graph.input, model.graph.initializer)
+    onnx_model = make_model(graph)
+    onnx_model.ir_version = model.ir_version
+    onnx_model.producer_name = model.producer_name
+    onnx_model.producer_version = model.producer_version
+    onnx_model.domain = model.domain
+    onnx_model.model_version = model.model_version
+    onnx_model.doc_string = model.doc_string
+    if len(model.metadata_props) > 0:
+        values = {p.key: p.value for p in model.metadata_props}
+        onnx.helper.set_model_props(onnx_model, values)
+
+    # fix opset import
+    versions = _build_op_version()
+    for oimp in model.opset_import:
+        op_set = onnx_model.opset_import.add()
+        op_set.domain = oimp.domain
+        if oimp.domain in new_opsets:
+            _check_possible_opset(versions, model.graph.node,
+                                  oimp.domain, oimp.version,
+                                  new_opsets[oimp.domain])
+            op_set.version = new_opsets[oimp.domain]
+        else:
+            op_set.version = oimp.version
+    return onnx_model

--- a/tests/test_onnx_rare_helper.py
+++ b/tests/test_onnx_rare_helper.py
@@ -1,0 +1,48 @@
+"""
+Tests on functions in *onnx_helper*.
+"""
+import unittest
+from sklearn.datasets import load_iris
+from sklearn.cluster import KMeans
+from sklearn.neighbors import NearestNeighbors
+from skl2onnx import convert_sklearn
+from skl2onnx.common.data_types import FloatTensorType
+from skl2onnx.helpers.onnx_rare_helper import upgrade_opset_number
+
+
+class TestOnnxRareHelper(unittest.TestCase):
+
+    def test_kmeans_upgrade(self):
+        data = load_iris()
+        X = data.data
+        model = KMeans(n_clusters=3)
+        model.fit(X)
+        model_onnx = convert_sklearn(model, "kmeans",
+                                     [("input", FloatTensorType([None, 4]))],
+                                     target_opset=7)
+        model8 = upgrade_opset_number(model_onnx, 8)
+        assert "version: 8" in str(model8)
+
+    def test_knn_upgrade(self):
+        iris = load_iris()
+        X, _ = iris.data, iris.target
+
+        clr = NearestNeighbors(n_neighbors=3)
+        clr.fit(X)
+
+        model_onnx = convert_sklearn(clr, "up",
+                                     [("input", FloatTensorType([None, 4]))],
+                                     target_opset=9)
+        try:
+            upgrade_opset_number(model_onnx, 8)
+            raise AssertionError()
+        except RuntimeError:
+            pass
+        try:
+            upgrade_opset_number(model_onnx, 11)
+        except RuntimeError as e:
+            assert "was updated" in str(e)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_onnx_rare_helper.py
+++ b/tests/test_onnx_rare_helper.py
@@ -5,6 +5,7 @@ import unittest
 from sklearn.datasets import load_iris
 from sklearn.cluster import KMeans
 from sklearn.neighbors import NearestNeighbors
+from onnx.defs import onnx_opset_version
 from skl2onnx import convert_sklearn
 from skl2onnx.common.data_types import FloatTensorType
 from skl2onnx.helpers.onnx_rare_helper import upgrade_opset_number
@@ -23,6 +24,8 @@ class TestOnnxRareHelper(unittest.TestCase):
         model8 = upgrade_opset_number(model_onnx, 8)
         assert "version: 8" in str(model8)
 
+    @unittest.skipIf(onnx_opset_version() <= 11,
+                     reason="Needs opset >= 11")
     def test_knn_upgrade(self):
         iris = load_iris()
         X, _ = iris.data, iris.target


### PR DESCRIPTION
The converter chooses an opset equal to max(opset) for all opset in node opset version < target_opset. Then the final opset_version maybe < to target_opset. the PR adds a function to upgrade opset number of a domain but it checks no operator was updated in onnx spec between the old version and the new one.