### PR TITLE
Implements option decision_leaf for decision trees (fixes #562)

### DIFF
--- a/docs/tutorial/plot_dbegin_options.py
+++ b/docs/tutorial/plot_dbegin_options.py
@@ -75,21 +75,23 @@ a way to specify which classifier should keep its *ZipMap*
 and which is not. So it is possible to specify options by id.
 """
 
-from pyquickhelper.helpgen.graphviz_helper import plot_graphviz
 from pprint import pformat
-from skl2onnx.common._registration import _converter_pool
+import numpy
+from pyquickhelper.helpgen.graphviz_helper import plot_graphviz
+from sklearn.ensemble import RandomForestClassifier
 from sklearn.preprocessing import MinMaxScaler
 from sklearn.pipeline import Pipeline
-import numpy
 from sklearn.datasets import load_iris
 from sklearn.model_selection import train_test_split
 from sklearn.linear_model import LogisticRegression
+from skl2onnx.common._registration import _converter_pool
 from skl2onnx import to_onnx
+from onnxruntime import InferenceSession
 from mlprodict.onnxrt import OnnxInference
 
 iris = load_iris()
 X, y = iris.data, iris.target
-X_train, _, y_train, __ = train_test_split(X, y, random_state=11)
+X_train, X_test, y_train, _ = train_test_split(X, y, random_state=11)
 clr = LogisticRegression()
 clr.fit(X_train, y_train)
 
@@ -201,7 +203,6 @@ model_def = to_onnx(
 oinf = OnnxInference(model_def, runtime='python_compiled')
 print(oinf.run({'X': X.astype(numpy.float32)[:5]}))
 
-
 #########################################
 # It did not seem to work... We need to tell
 # that applies on a specific part of the pipeline
@@ -228,6 +229,35 @@ print(oinf.run({'X': X.astype(numpy.float32)[:5]}))
 
 #########################################
 # Negative figures. We still have raw scores.
+
+#######################################
+# Option *decision_path*
+# ++++++++++++++++++++++
+#
+# *scikit-learn* implements a function to retrieve the
+# decision path. It can be enabled by option *decision_path*.
+
+clrrf = RandomForestClassifier(n_estimators=2, max_depth=2)
+clrrf.fit(X_train, y_train)
+clrrf.predict(X_test[:2])
+paths, n_nodes_ptr = clrrf.decision_path(X_test[:2])
+print(paths.todense())
+
+model_def = to_onnx(clrrf, X_train.astype(numpy.float32),
+                    options={id(clrrf): {'decision_path': True,
+                                         'zipmap': False}})
+sess = InferenceSession(model_def.SerializeToString())
+
+##########################################
+# The model produces 3 outputs.
+
+print([o.name for o in sess.get_outputs()])
+
+##########################################
+# Let's display the last one.
+
+res = sess.run(None, {'X': X_test[:2].astype(numpy.float32)})
+print(res[-1])
 
 ############################################################
 # List of available options

--- a/skl2onnx/_parse.py
+++ b/skl2onnx/_parse.py
@@ -174,6 +174,12 @@ def _parse_sklearn_simple_model(scope, model, inputs, custom_parsers=None):
             'decision_path', StringTensorType())
         this_operator.outputs.append(dec_path)
 
+    options = scope.get_options(model, dict(decision_leaf=False), fail=False)
+    if options is not None and options['decision_leaf']:
+        dec_path = scope.declare_local_variable(
+            'decision_leaf', Int64TensorType())
+        this_operator.outputs.append(dec_path)
+
     return this_operator.outputs
 
 

--- a/skl2onnx/common/shape_calculator.py
+++ b/skl2onnx/common/shape_calculator.py
@@ -35,11 +35,14 @@ def calculate_linear_classifier_output_shapes(operator):
     _calculate_linear_classifier_output_shapes(operator)
 
 
-def _calculate_linear_classifier_output_shapes(operator, decision_path=False):
+def _calculate_linear_classifier_output_shapes(
+        operator, decision_path=False, decision_leaf=False):
+    n_out = 0
     if decision_path:
-        out_range = [2, 3]
-    else:
-        out_range = [1, 2]
+        n_out += 1
+    if decision_leaf:
+        n_out += 1
+    out_range = [2, 2 + n_out]
     check_input_and_output_numbers(operator, input_count_range=1,
                                    output_count_range=out_range)
     check_input_and_output_types(operator, good_input_types=[
@@ -95,6 +98,10 @@ def _calculate_linear_classifier_output_shapes(operator, decision_path=False):
     else:
         raise ValueError('Label types must be all integers or all strings.')
 
+    # decision_path, decision_leaf
+    for n in range(2, len(operator.outputs)):
+        operator.outputs[n].type.shape = [N, 1]
+
 
 def calculate_linear_regressor_output_shapes(operator):
     """
@@ -124,3 +131,7 @@ def calculate_linear_regressor_output_shapes(operator):
             N, operator.raw_operator.coef_.shape[1]])
     else:
         operator.outputs[0].type = cls_type([N, 1])
+
+    # decision_path, decision_leaf
+    for n in range(1, len(operator.outputs)):
+        operator.outputs[n].type.shape = [N, 1]

--- a/skl2onnx/operator_converters/decision_tree.py
+++ b/skl2onnx/operator_converters/decision_tree.py
@@ -161,6 +161,56 @@ def predict(model, scope, operator, container,
     return transposed_result_name
 
 
+def _append_decision_output(
+        input_name, attrs, fct_label, n_out, scope, operator, container,
+        op_type='TreeEnsembleClassifier',
+        op_domain='ai.onnx.ml', op_version=1,
+        cast_encode=False, regression=False, dtype=np.float32):
+
+    attrs = attrs.copy()
+    attrs['name'] = scope.get_unique_operator_name(op_type)
+    attrs['n_targets'] = 1
+    attrs['post_transform'] = 'NONE'
+    if regression:
+        attrs['target_weights'] = np.array(
+            [float(_) for _ in attrs['target_nodeids']], dtype=dtype)
+    else:
+        attrs['target_ids'] = [0 for _ in attrs['class_ids']]
+        attrs['target_weights'] = [float(_) for _ in attrs['class_nodeids']]
+        attrs['target_nodeids'] = attrs['class_nodeids']
+        attrs['target_treeids'] = attrs['class_treeids']
+
+    rem = [k for k in attrs if k.startswith('class')]
+    for k in rem:
+        del attrs[k]
+    dpath = scope.get_unique_variable_name("dpath")
+    container.add_node(
+        op_type.replace("Classifier", "Regressor"), input_name, dpath,
+        op_domain=op_domain, op_version=op_version, **attrs)
+
+    if cast_encode:
+        apply_cast(
+            scope, dpath, operator.outputs[n_out].full_name,
+            container, to=onnx_proto.TensorProto.INT64,
+            operator_name=scope.get_unique_operator_name('TreePathType'))
+    else:
+        op = operator.raw_operator
+        labels = fct_label(op.tree_)
+        ordered = list(sorted(labels.items()))
+        keys = [float(_[0]) for _ in ordered]
+        values = [_[1] for _ in ordered]
+        name = scope.get_unique_variable_name("spath")
+        container.add_node(
+            'LabelEncoder', dpath, name,
+            op_domain=op_domain, op_version=2,
+            default_string='0', keys_floats=keys, values_strings=values,
+            name=scope.get_unique_operator_name('TreePath'))
+        apply_reshape(
+            scope, name, operator.outputs[n_out].full_name,
+            container, desired_shape=(-1, 1),
+            operator_name=scope.get_unique_operator_name('TreePathShape'))
+
+
 def convert_sklearn_decision_tree_classifier(
         scope, operator, container, op_type='TreeEnsembleClassifier',
         op_domain='ai.onnx.ml', op_version=1):
@@ -172,7 +222,8 @@ def convert_sklearn_decision_tree_classifier(
     if dtype != np.float64:
         dtype = np.float32
     op = operator.raw_operator
-    options = scope.get_options(op, dict(decision_path=False))
+    options = scope.get_options(
+            op, dict(decision_path=False, decision_leaf=False))
     if op.n_outputs_ == 1:
         attrs = get_default_tree_classifier_attribute_pairs()
         attrs['name'] = scope.get_unique_operator_name(op_type)
@@ -212,40 +263,24 @@ def convert_sklearn_decision_tree_classifier(
             [operator.outputs[0].full_name, operator.outputs[1].full_name],
             op_domain=op_domain, op_version=op_version, **attrs)
 
-        if not options['decision_path']:
-            return
-
-        # decision_path
-        attrs = attrs.copy()
-        attrs['name'] = scope.get_unique_operator_name(op_type)
-        attrs['n_targets'] = 1
-        attrs['post_transform'] = 'NONE'
-        attrs['target_ids'] = [0 for _ in attrs['class_ids']]
-        attrs['target_weights'] = [float(_) for _ in attrs['class_nodeids']]
-        attrs['target_nodeids'] = attrs['class_nodeids']
-        attrs['target_treeids'] = attrs['class_treeids']
-        rem = [k for k in attrs if k.startswith('class')]
-        for k in rem:
-            del attrs[k]
-        dpath = scope.get_unique_variable_name("dpath")
-        container.add_node(
-            op_type.replace("Classifier", "Regressor"), input_name, dpath,
-            op_domain=op_domain, op_version=op_version, **attrs)
-
-        labels = _build_labels(op.tree_)
-        ordered = list(sorted(labels.items()))
-        keys = [float(_[0]) for _ in ordered]
-        values = [_[1] for _ in ordered]
-        name = scope.get_unique_variable_name("spath")
-        container.add_node(
-            'LabelEncoder', dpath, name,
-            op_domain=op_domain, op_version=2,
-            default_string='0', keys_floats=keys, values_strings=values,
-            name=scope.get_unique_operator_name('TreePath'))
-        apply_reshape(
-            scope, name, operator.outputs[2].full_name,
-            container, desired_shape=(-1, 1),
-            operator_name=scope.get_unique_operator_name('TreePathShape'))
+        n_out = 2
+        if options['decision_path']:
+            # decision_path
+            _append_decision_output(
+                input_name, attrs, _build_labels_path, n_out,
+                scope, operator, container,
+                op_type=op_type, op_domain=op_domain,
+                op_version=op_version, dtype=dtype)
+            n_out += 1
+        if options['decision_leaf']:
+            # decision_path
+            _append_decision_output(
+                input_name, attrs, _build_labels_leaf, n_out,
+                scope, operator, container,
+                op_type=op_type, op_domain=op_domain,
+                op_version=op_version, cast_encode=True,
+                dtype=dtype)
+            n_out += 1
     else:
         transposed_result_name = predict(
             op, scope, operator, container, op_type, op_domain, op_version)
@@ -290,7 +325,12 @@ def convert_sklearn_decision_tree_classifier(
 
         if options['decision_path']:
             raise RuntimeError(
-                "Decision output for multi-outputs is not implemented yet.")
+                "Option decision_path for multi-outputs "
+                "is not implemented yet.")
+        if options['decision_leaf']:
+            raise RuntimeError(
+                "Option decision_leaf for multi-outputs "
+                "is not implemented yet.")
 
 
 def convert_sklearn_decision_tree_regressor(
@@ -326,11 +366,29 @@ def convert_sklearn_decision_tree_regressor(
         op_type, input_name, operator.outputs[0].full_name,
         op_domain=op_domain, op_version=op_version, **attrs)
 
-    options = scope.get_options(op, dict(decision_path=False))
-    if not options['decision_path']:
-        return
+    options = scope.get_options(
+        op, dict(decision_path=False, decision_leaf=False))
 
     # decision_path
+    n_out = 1
+    if options['decision_path']:
+        # decision_path
+        _append_decision_output(
+            input_name, attrs, _build_labels_path, n_out,
+            scope, operator, container,
+            op_type=op_type, op_domain=op_domain,
+            op_version=op_version, regression=True)
+        n_out += 1
+    if options['decision_leaf']:
+        # decision_path
+        _append_decision_output(
+            input_name, attrs, _build_labels_leaf, n_out,
+            scope, operator, container,
+            op_type=op_type, op_domain=op_domain,
+            op_version=op_version, regression=True, cast_encode=True)
+        n_out += 1
+
+    """
     attrs = attrs.copy()
     attrs['name'] = scope.get_unique_operator_name(op_type)
     attrs['n_targets'] = 1
@@ -343,7 +401,7 @@ def convert_sklearn_decision_tree_regressor(
         op_type, input_name, dpath,
         op_domain=op_domain, op_version=op_version, **attrs)
 
-    labels = _build_labels(op.tree_)
+    labels = _build_labels_path(op.tree_)
     ordered = list(sorted(labels.items()))
     keys = [float(_[0]) for _ in ordered]
     values = [_[1] for _ in ordered]
@@ -357,26 +415,28 @@ def convert_sklearn_decision_tree_regressor(
         scope, name, operator.outputs[1].full_name,
         container, desired_shape=(-1, 1),
         operator_name=scope.get_unique_operator_name('TreePathShape'))
+    """
 
 
-def _build_labels(tree):
-    def _recursive_build_labels(index, current):
-        current[index] = True
-        if tree.children_left[index] == -1:
-            yield (index, current.copy())
-        else:
-            for it in _recursive_build_labels(
-                    tree.children_left[index], current):
-                yield it
-            for it in _recursive_build_labels(
-                    tree.children_right[index], current):
-                yield it
-        current[index] = False
+def _recursive_build_labels(tree, index, current):
+    current[index] = True
+    if tree.children_left[index] == -1:
+        yield (index, current.copy())
+    else:
+        for it in _recursive_build_labels(
+                tree, tree.children_left[index], current):
+            yield it
+        for it in _recursive_build_labels(
+                tree, tree.children_right[index], current):
+            yield it
+    current[index] = False
 
+
+def _build_labels_path(tree):
     paths = {}
     current = {}
 
-    for leave_index, path in _recursive_build_labels(0, current):
+    for leave_index, path in _recursive_build_labels(tree, 0, current):
         spath = ["0" for _ in range(tree.node_count)]
         for nodeid, b in path.items():
             if b:
@@ -385,19 +445,32 @@ def _build_labels(tree):
     return paths
 
 
+def _build_labels_leaf(tree):
+    paths = {}
+    current = {}
+
+    for leave_index, path in _recursive_build_labels(tree, 0, current):
+        paths[leave_index] = leave_index
+    return paths
+
+
 register_converter('SklearnDecisionTreeClassifier',
                    convert_sklearn_decision_tree_classifier,
                    options={'zipmap': [True, False, 'columns'],
                             'nocl': [True, False],
-                            'decision_path': [True, False]})
+                            'decision_path': [True, False],
+                            'decision_leaf': [True, False]})
 register_converter('SklearnDecisionTreeRegressor',
                    convert_sklearn_decision_tree_regressor,
-                   options={'decision_path': [True, False]})
+                   options={'decision_path': [True, False],
+                            'decision_leaf': [True, False]})
 register_converter('SklearnExtraTreeClassifier',
                    convert_sklearn_decision_tree_classifier,
                    options={'zipmap': [True, False, 'columns'],
                             'nocl': [True, False],
-                            'decision_path': [True, False]})
+                            'decision_path': [True, False],
+                            'decision_leaf': [True, False]})
 register_converter('SklearnExtraTreeRegressor',
                    convert_sklearn_decision_tree_regressor,
-                   options={'decision_path': [True, False]})
+                   options={'decision_path': [True, False],
+                            'decision_leaf': [True, False]})

--- a/skl2onnx/operator_converters/random_forest.py
+++ b/skl2onnx/operator_converters/random_forest.py
@@ -100,7 +100,8 @@ def convert_sklearn_random_forest_classifier(
     if hasattr(op, 'n_outputs_'):
         n_outputs = int(op.n_outputs_)
         options = container.get_options(
-            op, dict(raw_scores=False, decision_path=False))
+            op, dict(raw_scores=False, decision_path=False,
+                     decision_leaf=False))
     elif hasattr(op, 'n_trees_per_iteration_'):
         # HistGradientBoostingClassifier
         n_outputs = op.n_trees_per_iteration_
@@ -216,11 +217,13 @@ def convert_sklearn_random_forest_classifier(
             [operator.outputs[0].full_name, operator.outputs[1].full_name],
             op_domain=op_domain, op_version=op_version, **attr_pairs)
 
-        if not options.get('decision_path', False):
+        if (not options.get('decision_path', False) and
+                not options.get('decision_leaf', False)):
             return
 
         # decision_path
         tree_paths = []
+        tree_leaves = []
         for i, tree in enumerate(op.estimators_):
 
             attrs = get_default_tree_classifier_attribute_pairs()
@@ -254,27 +257,41 @@ def convert_sklearn_random_forest_classifier(
                 op_type.replace("Classifier", "Regressor"), input_name, dpath,
                 op_domain=op_domain, op_version=op_version, **attrs)
 
-            labels = _build_labels_path(tree.tree_)
-            ordered = list(sorted(labels.items()))
-            keys = [float(_[0]) for _ in ordered]
-            values = [_[1] for _ in ordered]
-            name = scope.get_unique_variable_name('spath%d' % i)
-            container.add_node(
-                'LabelEncoder', dpath, name,
-                op_domain=op_domain, op_version=2,
-                default_string='0', keys_floats=keys, values_strings=values,
-                name=scope.get_unique_operator_name('TreePath'))
-            name_shape = scope.get_unique_variable_name('spath%d' % i)
-            apply_reshape(
-                scope, name, name_shape,
-                container, desired_shape=(-1, 1),
-                operator_name=scope.get_unique_operator_name('sdpath2d%d' % i))
-            tree_paths.append(name_shape)
+            if options['decision_path']:
+                # decision_path
+                tree_paths.append(
+                    _append_decision_output(
+                        input_name, attrs, _build_labels_path, None,
+                        scope, operator, container,
+                        op_type=op_type, op_domain=op_domain,
+                        op_version=op_version, regression=True,
+                        overwrite_tree=tree.tree_))
+            if options['decision_leaf']:
+                # decision_path
+                tree_leaves.append(
+                    _append_decision_output(
+                        input_name, attrs, _build_labels_leaf, None,
+                        scope, operator, container,
+                        op_type=op_type, op_domain=op_domain,
+                        op_version=op_version, regression=True,
+                        cast_encode=True))
 
         # merges everything
-        apply_concat(
-            scope, tree_paths, operator.outputs[2].full_name, container,
-            axis=1, operator_name=scope.get_unique_operator_name('concat'))
+        n_out = 2
+        if options['decision_path']:
+            apply_concat(
+                scope, tree_paths, operator.outputs[n_out].full_name,
+                container, axis=1,
+                operator_name=scope.get_unique_operator_name('concat'))
+            n_out += 1
+
+        if options['decision_leaf']:
+            # decision_path
+            apply_concat(
+                scope, tree_leaves, operator.outputs[n_out].full_name,
+                container, axis=1,
+                operator_name=scope.get_unique_operator_name('concat'))
+            n_out += 1
 
     else:
         if use_raw_scores:
@@ -306,7 +323,8 @@ def convert_sklearn_random_forest_classifier(
         apply_concat(scope, predictions, operator.outputs[0].full_name,
                      container, axis=1)
 
-        if options.get('decision_path', False):
+        if (options.get('decision_path', False) or
+                options.get('decision_leaf', False)):
             raise RuntimeError(
                 "Decision output for multi-outputs is not implemented yet.")
 

--- a/skl2onnx/operator_converters/random_forest.py
+++ b/skl2onnx/operator_converters/random_forest.py
@@ -24,7 +24,7 @@ from ..common.tree_ensemble import (
 )
 from ..common.utils_classifier import get_label_classes
 from ..proto import onnx_proto
-from .decision_tree import predict, _build_labels
+from .decision_tree import predict, _build_labels_path
 
 
 def _num_estimators(op):
@@ -253,7 +253,7 @@ def convert_sklearn_random_forest_classifier(
                 op_type.replace("Classifier", "Regressor"), input_name, dpath,
                 op_domain=op_domain, op_version=op_version, **attrs)
 
-            labels = _build_labels(tree.tree_)
+            labels = _build_labels_path(tree.tree_)
             ordered = list(sorted(labels.items()))
             keys = [float(_[0]) for _ in ordered]
             values = [_[1] for _ in ordered]
@@ -420,7 +420,7 @@ def convert_sklearn_random_forest_regressor_converter(
             op_type, input_name, dpath,
             op_domain=op_domain, op_version=op_version, **attrs)
 
-        labels = _build_labels(tree.tree_)
+        labels = _build_labels_path(tree.tree_)
         ordered = list(sorted(labels.items()))
         keys = [float(_[0]) for _ in ordered]
         values = [_[1] for _ in ordered]

--- a/skl2onnx/shape_calculators/ensemble_shapes.py
+++ b/skl2onnx/shape_calculators/ensemble_shapes.py
@@ -29,30 +29,38 @@ def calculate_tree_regressor_output_shapes(operator):
     [N, 1].
     """
     check_input_and_output_numbers(operator, input_count_range=1,
-                                   output_count_range=[1, 2])
+                                   output_count_range=[1, 3])
     check_input_and_output_types(operator, good_input_types=[
         BooleanTensorType, DoubleTensorType,
         FloatTensorType, Int64TensorType])
 
     N = operator.inputs[0].type.shape[0]
     operator.outputs[0].type.shape = [N, 1]
-    if len(operator.outputs) == 2:
+
+    # decision_path, decision_leaf
+    for n in range(2, len(operator.outputs)):
         if hasattr(operator.raw_operator, 'estimators_'):
-            operator.outputs[1].type.shape = [
+            # random forest
+            operator.outputs[n].type.shape = [
                 N, len(operator.raw_operator.estimators_)]
         else:
-            operator.outputs[1].type.shape = [N, 1]
+            # single tree
+            operator.outputs[n].type.shape = [N, 1]
 
 
 def calculate_tree_classifier_output_shapes(operator):
-    _calculate_linear_classifier_output_shapes(operator, True)
-    if len(operator.outputs) == 3:
-        N = operator.inputs[0].type.shape[0]
+    _calculate_linear_classifier_output_shapes(operator, True, True)
+    N = operator.inputs[0].type.shape[0]
+
+    # decision_path, decision_leaf
+    for n in range(2, len(operator.outputs)):
         if hasattr(operator.raw_operator, 'estimators_'):
-            operator.outputs[2].type.shape = [
+            # random forest
+            operator.outputs[n].type.shape = [
                 N, len(operator.raw_operator.estimators_)]
         else:
-            operator.outputs[2].type.shape = [N, 1]
+            # single tree
+            operator.outputs[n].type.shape = [N, 1]
 
 
 register_shape_calculator('SklearnDecisionTreeRegressor',

--- a/tests/test_sklearn_random_forest_converters.py
+++ b/tests/test_sklearn_random_forest_converters.py
@@ -734,7 +734,7 @@ class TestSklearnTreeEnsembleModels(unittest.TestCase):
     @unittest.skipIf(TARGET_OPSET < 12, reason="LabelEncoder")
     def test_rf_regressor_decision_leaf(self):
         model = RandomForestRegressor(n_estimators=2, max_depth=3)
-        X, y = make_classification(10, n_features=4, random_state=42)
+        X, y = make_regression(10, n_features=4, random_state=42)
         X = X[:, :2]
         model.fit(X, y)
         initial_types = [('input', FloatTensorType((None, X.shape[1])))]
@@ -744,7 +744,7 @@ class TestSklearnTreeEnsembleModels(unittest.TestCase):
         sess = InferenceSession(model_onnx.SerializeToString())
         res = sess.run(None, {'input': X.astype(numpy.float32)})
         pred = model.predict(X)
-        assert_almost_equal(pred, res[0].ravel())
+        assert_almost_equal(pred, res[0].ravel(), decimal=4)
         dec = model.decision_path(X)
         exp = path_to_leaf(model.estimators_, dec[0].todense(), dec[1])
         assert exp.tolist() == res[1].tolist()
@@ -754,7 +754,7 @@ class TestSklearnTreeEnsembleModels(unittest.TestCase):
     @unittest.skipIf(TARGET_OPSET < 12, reason="LabelEncoder")
     def test_rf_regressor_decision_path_leaf(self):
         model = RandomForestRegressor(n_estimators=3, max_depth=3)
-        X, y = make_classification(10, n_features=4, random_state=42)
+        X, y = make_regression(10, n_features=4, random_state=42)
         X = X[:, :2]
         model.fit(X, y)
         initial_types = [('input', FloatTensorType((None, X.shape[1])))]
@@ -765,13 +765,58 @@ class TestSklearnTreeEnsembleModels(unittest.TestCase):
         sess = InferenceSession(model_onnx.SerializeToString())
         res = sess.run(None, {'input': X.astype(numpy.float32)})
         pred = model.predict(X)
-        assert_almost_equal(pred, res[0].ravel())
+        assert_almost_equal(pred, res[0].ravel(), decimal=4)
         dec = model.decision_path(X)
         exp_leaf = path_to_leaf(model.estimators_, dec[0].todense(), dec[1])
         exp_path = binary_array_to_string(dec[0].todense())
         got_path = numpy.array([''.join(row) for row in res[1]])
         assert exp_path == got_path.ravel().tolist()
         assert exp_leaf.tolist() == res[2].tolist()
+
+    @unittest.skipIf(not onnx_built_with_ml(),
+                     reason="Requires ONNX-ML extension.")
+    @unittest.skipIf(TARGET_OPSET < 12, reason="LabelEncoder")
+    def test_rf_classifier_decision_leaf(self):
+        model = RandomForestClassifier(n_estimators=2, max_depth=3)
+        X, y = make_classification(3, n_features=4, random_state=42)
+        X = X[:, :2]
+        model.fit(X, y)
+        initial_types = [('input', FloatTensorType((None, X.shape[1])))]
+        model_onnx = convert_sklearn(
+            model, initial_types=initial_types,
+            options={id(model): {'decision_leaf': True, 'zipmap': False}})
+        sess = InferenceSession(model_onnx.SerializeToString())
+        res = sess.run(None, {'input': X.astype(numpy.float32)})
+        pred = model.predict(X)
+        assert_almost_equal(pred, res[0].ravel())
+        dec = model.decision_path(X)
+        exp = path_to_leaf(model.estimators_, dec[0].todense(), dec[1])
+        assert exp.tolist() == res[2].tolist()
+
+    @unittest.skipIf(not onnx_built_with_ml(),
+                     reason="Requires ONNX-ML extension.")
+    @unittest.skipIf(TARGET_OPSET < 12, reason="LabelEncoder")
+    def test_rf_classifier_decision_path_leaf(self):
+        model = RandomForestClassifier(n_estimators=3, max_depth=3)
+        X, y = make_classification(3, n_features=4, random_state=42)
+        X = X[:, :2]
+        model.fit(X, y)
+        initial_types = [('input', FloatTensorType((None, X.shape[1])))]
+        model_onnx = convert_sklearn(
+            model, initial_types=initial_types,
+            options={id(model): {'decision_leaf': True,
+                                 'decision_path': True,
+                                 'zipmap': False}})
+        sess = InferenceSession(model_onnx.SerializeToString())
+        res = sess.run(None, {'input': X.astype(numpy.float32)})
+        pred = model.predict(X)
+        assert_almost_equal(pred, res[0].ravel())
+        dec = model.decision_path(X)
+        exp_leaf = path_to_leaf(model.estimators_, dec[0].todense(), dec[1])
+        exp_path = binary_array_to_string(dec[0].todense())
+        got_path = numpy.array([''.join(row) for row in res[2]])
+        assert exp_path == got_path.ravel().tolist()
+        assert exp_leaf.tolist() == res[3].tolist()
 
 
 if __name__ == "__main__":

--- a/tests/test_sklearn_random_forest_converters.py
+++ b/tests/test_sklearn_random_forest_converters.py
@@ -742,7 +742,8 @@ class TestSklearnTreeEnsembleModels(unittest.TestCase):
         initial_types = [('input', FloatTensorType((None, X.shape[1])))]
         model_onnx = convert_sklearn(
             model, initial_types=initial_types,
-            options={id(model): {'decision_leaf': True}})
+            options={id(model): {'decision_leaf': True}},
+            target_opset=TARGET_OPSET)
         sess = InferenceSession(model_onnx.SerializeToString())
         res = sess.run(None, {'input': X.astype(numpy.float32)})
         pred = model.predict(X)
@@ -763,7 +764,8 @@ class TestSklearnTreeEnsembleModels(unittest.TestCase):
         model_onnx = convert_sklearn(
             model, initial_types=initial_types,
             options={id(model): {'decision_leaf': True,
-                                 'decision_path': True}})
+                                 'decision_path': True}},
+            target_opset=TARGET_OPSET)
         sess = InferenceSession(model_onnx.SerializeToString())
         res = sess.run(None, {'input': X.astype(numpy.float32)})
         pred = model.predict(X)
@@ -786,7 +788,8 @@ class TestSklearnTreeEnsembleModels(unittest.TestCase):
         initial_types = [('input', FloatTensorType((None, X.shape[1])))]
         model_onnx = convert_sklearn(
             model, initial_types=initial_types,
-            options={id(model): {'decision_leaf': True, 'zipmap': False}})
+            options={id(model): {'decision_leaf': True, 'zipmap': False}},
+            target_opset=TARGET_OPSET)
         sess = InferenceSession(model_onnx.SerializeToString())
         res = sess.run(None, {'input': X.astype(numpy.float32)})
         pred = model.predict(X)
@@ -808,7 +811,8 @@ class TestSklearnTreeEnsembleModels(unittest.TestCase):
             model, initial_types=initial_types,
             options={id(model): {'decision_leaf': True,
                                  'decision_path': True,
-                                 'zipmap': False}})
+                                 'zipmap': False}},
+            target_opset=TARGET_OPSET)
         sess = InferenceSession(model_onnx.SerializeToString())
         res = sess.run(None, {'input': X.astype(numpy.float32)})
         pred = model.predict(X)

--- a/tests/test_sklearn_random_forest_converters.py
+++ b/tests/test_sklearn_random_forest_converters.py
@@ -40,6 +40,7 @@ from test_utils import (
     fit_classification_model,
     fit_multilabel_classification_model,
     fit_regression_model,
+    path_to_leaf,
     TARGET_OPSET,
 )
 try:
@@ -727,6 +728,50 @@ class TestSklearnTreeEnsembleModels(unittest.TestCase):
         exp = binary_array_to_string(dec[0].todense())
         got = numpy.array([''.join(row) for row in res[2]])
         assert exp == got.ravel().tolist()
+
+    @unittest.skipIf(not onnx_built_with_ml(),
+                     reason="Requires ONNX-ML extension.")
+    @unittest.skipIf(TARGET_OPSET < 12, reason="LabelEncoder")
+    def test_rf_regressor_decision_leaf(self):
+        model = RandomForestRegressor(n_estimators=2, max_depth=3)
+        X, y = make_classification(10, n_features=4, random_state=42)
+        X = X[:, :2]
+        model.fit(X, y)
+        initial_types = [('input', FloatTensorType((None, X.shape[1])))]
+        model_onnx = convert_sklearn(
+            model, initial_types=initial_types,
+            options={id(model): {'decision_leaf': True}})
+        sess = InferenceSession(model_onnx.SerializeToString())
+        res = sess.run(None, {'input': X.astype(numpy.float32)})
+        pred = model.predict(X)
+        assert_almost_equal(pred, res[0].ravel())
+        dec = model.decision_path(X)
+        exp = path_to_leaf(model.estimators_, dec[0].todense(), dec[1])
+        assert exp.tolist() == res[1].tolist()
+
+    @unittest.skipIf(not onnx_built_with_ml(),
+                     reason="Requires ONNX-ML extension.")
+    @unittest.skipIf(TARGET_OPSET < 12, reason="LabelEncoder")
+    def test_rf_regressor_decision_path_leaf(self):
+        model = RandomForestRegressor(n_estimators=3, max_depth=3)
+        X, y = make_classification(10, n_features=4, random_state=42)
+        X = X[:, :2]
+        model.fit(X, y)
+        initial_types = [('input', FloatTensorType((None, X.shape[1])))]
+        model_onnx = convert_sklearn(
+            model, initial_types=initial_types,
+            options={id(model): {'decision_leaf': True,
+                                 'decision_path': True}})
+        sess = InferenceSession(model_onnx.SerializeToString())
+        res = sess.run(None, {'input': X.astype(numpy.float32)})
+        pred = model.predict(X)
+        assert_almost_equal(pred, res[0].ravel())
+        dec = model.decision_path(X)
+        exp_leaf = path_to_leaf(model.estimators_, dec[0].todense(), dec[1])
+        exp_path = binary_array_to_string(dec[0].todense())
+        got_path = numpy.array([''.join(row) for row in res[1]])
+        assert exp_path == got_path.ravel().tolist()
+        assert exp_leaf.tolist() == res[2].tolist()
 
 
 if __name__ == "__main__":

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -20,7 +20,8 @@ from .tests_helper import (  # noqa
     fit_classification_model,
     fit_multilabel_classification_model,
     fit_regression_model,
-    binary_array_to_string
+    binary_array_to_string,
+    path_to_leaf
 )
 
 

--- a/tests/test_utils/tests_helper.py
+++ b/tests/test_utils/tests_helper.py
@@ -986,17 +986,28 @@ def binary_array_to_string(mat):
     return [''.join(row) for row in res]
 
 
-def path_to_leaf(tree, mat):
-    leave = set([i for i in range(tree.node_count)
-                 if tree.children_left[i] <= i])
-    res = []
-    for row in range(mat.shape[0]):
-        leaf = None
-        for i in range(mat.shape[1]):
-            if mat[row, i] == 1 and i in leave:
-                leaf = i
-                break
-        if leaf is None:
-            raise AssertionError("Path does not end with a leaf.")
-        res.append(leaf)
-    return numpy.array(res, numpy.int64)
+def path_to_leaf(tree, mat, tree_indices=None):
+    if tree_indices is None:
+        # single tree
+        leave = set([i for i in range(tree.node_count)
+                     if tree.children_left[i] <= i])
+        res = []
+        for row in range(mat.shape[0]):
+            leaf = None
+            for i in range(mat.shape[1]):
+                if mat[row, i] == 1 and i in leave:
+                    leaf = i
+                    break
+            if leaf is None:
+                raise AssertionError("Path does not end with a leaf.")
+            res.append(leaf)
+        return numpy.array(res, numpy.int64)
+
+    leaves = []
+    for i in range(0, len(tree)):
+        mm = mat[:, tree_indices[i]:tree_indices[i+1]]
+        tt = tree[i].tree_ if hasattr(tree[i], 'tree_') else tree[i]
+        res = path_to_leaf(tt, mm)
+        leaves.append(numpy.array(res, dtype=numpy.int64))
+    res = numpy.vstack(leaves)
+    return res.T

--- a/tests/test_utils/tests_helper.py
+++ b/tests/test_utils/tests_helper.py
@@ -982,3 +982,19 @@ def binary_array_to_string(mat):
         raise NotImplementedError()
     res = [[str(i) for i in row] for row in mat.tolist()]
     return [''.join(row) for row in res]
+
+
+def path_to_leaf(tree, mat):
+    leave = set([i for i in range(tree.node_count)
+                 if tree.children_left[i] <= i])
+    res = []
+    for row in range(mat.shape[0]):
+        leaf = None
+        for i in range(mat.shape[1]):
+            if mat[row, i] == 1 and i in leave:
+                leaf = i
+                break
+        if leaf is None:
+            raise AssertionError("Path does not end with a leaf.")
+        res.append(leaf)
+    return numpy.array(res, numpy.int64)


### PR DESCRIPTION
Option *decision_path* adds an output to return decision path in a similar way than *scikit-learn* does but instead of returning a dense output (not available in onnxruntime), it returns the results as a list of strings, each character is either `'0'` or `'1'`. This option returns the leave index as an array of int64. It takes less memory space. A user can then use an encoder to transform that index into something else.