### PR TITLE
Remove trivial Runtime error in SVM converter

### DIFF
--- a/skl2onnx/operator_converters/support_vector_machines.py
+++ b/skl2onnx/operator_converters/support_vector_machines.py
@@ -244,10 +244,6 @@ def convert_sklearn_svm_classifier(
         #     transformed_confidences = (
         #         sum_of_confidences / (3 * (np.abs(sum_of_confidences) + 1)))
         #     return votes + transformed_confidences
-        # if list(op.classes_) != list(range(len(op.classes_))):
-        #     raise RuntimeError(
-        #         "Classes different from first n integers are not supported "
-        #         "in SVC converter.")
 
         proto_dtype = guess_proto_type(operator.inputs[0].type)
         if proto_dtype != onnx_proto.TensorProto.DOUBLE:

--- a/skl2onnx/operator_converters/support_vector_machines.py
+++ b/skl2onnx/operator_converters/support_vector_machines.py
@@ -244,10 +244,10 @@ def convert_sklearn_svm_classifier(
         #     transformed_confidences = (
         #         sum_of_confidences / (3 * (np.abs(sum_of_confidences) + 1)))
         #     return votes + transformed_confidences
-        if list(op.classes_) != list(range(len(op.classes_))):
-            raise RuntimeError(
-                "Classes different from first n integers are not supported "
-                "in SVC converter.")
+        # if list(op.classes_) != list(range(len(op.classes_))):
+        #     raise RuntimeError(
+        #         "Classes different from first n integers are not supported "
+        #         "in SVC converter.")
 
         proto_dtype = guess_proto_type(operator.inputs[0].type)
         if proto_dtype != onnx_proto.TensorProto.DOUBLE:


### PR DESCRIPTION
**Symptom**
`RuntimeError: Classes different from first n integers are not supported in SVC converter.`


**Step to reproduce**
1. Instantiate and t rain model
      ```
      from sklearn import svm
      clf = svm.SVC()
      clf.fit(X_train, y_train)
      ```
1. Save instance to memory
      ```
      from skl2onnx import convert_sklearn
      from skl2onnx.common.data_types import FloatTensorType
      
      filename = "cont_gaslift_back_press_status-SVM.onnx"
      initial_type=[('float_input', FloatTensorType([None, X_train.shape[1]]))]
      onx = convert_sklearn(clf, initial_types=initial_type)
      with open(filename, "wb") as f:
          f.write(onx.SerializeToString())
      ```
**As is**

```

---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-33-72faacfd727d> in <module>
      4 filename = "cont_gaslift_back_press_status-SVM.onnx"
      5 initial_type=[('float_input', FloatTensorType([None, X_train.shape[1]]))]
----> 6 onx = convert_sklearn(clf, initial_types=initial_type)
      7 with open(filename, "wb") as f:
      8     f.write(onx.SerializeToString())

~/.pyenv/versions/3.6.12/envs/ax-django/lib/python3.6/site-packages/skl2onnx/convert.py in convert_sklearn(model, name, initial_types, doc_string, target_opset, custom_conversion_functions, custom_shape_calculators, custom_parsers, options, dtype, intermediate, white_op, black_op, final_types)
    152     # Convert our Topology object into ONNX. The outcome is an ONNX model.
    153     onnx_model = convert_topology(topology, name, doc_string, target_opset,
--> 154                                   dtype=dtype, options=options)
    155 
    156     return (onnx_model, topology) if intermediate else onnx_model

~/.pyenv/versions/3.6.12/envs/ax-django/lib/python3.6/site-packages/skl2onnx/common/_topology.py in convert_topology(topology, model_name, doc_string, target_opset, channel_first_inputs, dtype, options)
   1052                               type(getattr(operator, 'raw_model', None))))
   1053         container.validate_options(operator)
-> 1054         conv(scope, operator, container)
   1055 
   1056     # Create a graph from its main components

~/.pyenv/versions/3.6.12/envs/ax-django/lib/python3.6/site-packages/skl2onnx/common/_registration.py in __call__(self, *args)
     27             if args[1].raw_operator is not None:
     28                 args[2]._get_allowed_options(args[1].raw_operator)
---> 29         return self._fct(*args)
     30 
     31     def get_allowed_options(self):

~/.pyenv/versions/3.6.12/envs/ax-django/lib/python3.6/site-packages/skl2onnx/operator_converters/support_vector_machines.py in convert_sklearn_svm_classifier(scope, operator, container, op_type, op_domain, op_version)
    218         #     return votes + transformed_confidences
    219         if list(op.classes_) != list(range(len(op.classes_))):
--> 220             raise RuntimeError("Classes different from first n integers are not supported in SVC converter.")
    221 
    222         cst3 = scope.get_unique_variable_name('cst3')

RuntimeError: Classes different from first n integers are not supported in SVC converter.
```

**Expected Result**
Be able to save to disk

**Workaround**
Remove `if` code block. I have tested with `MLP` model it works. Therefore the comparison here is trivial

