### PR TITLE
Raw name can have parenthesis.

### DIFF
--- a/skl2onnx/common/_topology.py
+++ b/skl2onnx/common/_topology.py
@@ -68,7 +68,7 @@ class Variable:
         :param type: A type object defined in .common.data_types.py;
                      e.g., FloatTensorType
         """
-        if not isinstance(raw_name, str) or '(' in raw_name:
+        if not isinstance(raw_name, str):
             raise TypeError(
                 "raw_name must be a string not '%s'." % raw_name.__class__)
         if not isinstance(onnx_name, str) or '(' in onnx_name:


### PR DESCRIPTION
**Symptom**

`TypeError: raw_name must be a string not '<class 'str'>'.`

**Steps to reproduce**

```
from skl2onnx.common._topology import Scope

scope = Scope("")
scope.declare_local_variable("(raw_name)")
```

**Produces**

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sklearn-onnx/skl2onnx/common/_topology.py", line 413, in declare_local_variable
    variable = Variable(raw_name, onnx_name, self.name, type)
  File "skl2onnx/common/_topology.py", line 72, in __init__
    raise TypeError(
TypeError: raw_name must be a string not '<class 'str'>'.
```

**Expected result**

Create a variable with raw name `(raw_name)` not return runtime error.

**What to do**

Modify checks when creating variables with `_topology.py`. The line that causes this is this [one](https://github.com/onnx/sklearn-onnx/blob/e1a12e0aa6916e507216837069f0e93aa8402992/skl2onnx/common/_topology.py#L71).

Is there any reason to enforce this? One use case where we could need parenthesis in a raw_name is when operating with pandas dataframes and we want to keep their column names as raw names for debugging purposes, or selection if based on column names.