### PR TITLE
Support certain special raw names

### DIFF
--- a/skl2onnx/common/_topology.py
+++ b/skl2onnx/common/_topology.py
@@ -68,7 +68,7 @@ class Variable:
         :param type: A type object defined in .common.data_types.py;
                      e.g., FloatTensorType
         """
-        if not isinstance(raw_name, str) or '(' in raw_name:
+        if not isinstance(raw_name, str):
             raise TypeError(
                 "raw_name must be a string not '%s'." % raw_name.__class__)
         if not isinstance(onnx_name, str) or '(' in onnx_name:

--- a/skl2onnx/common/_topology.py
+++ b/skl2onnx/common/_topology.py
@@ -1123,9 +1123,10 @@ def convert_topology(topology, model_name, doc_string, target_opset,
     nhwc_inputs = []
     if channel_first_inputs is None:
         channel_first_inputs = []
-    for name in topology.raw_model.input_names:
+    for variable in topology.raw_model._inputs:
+        name = variable.raw_name
         # Check input naming convention
-        input_name = name.replace('_', '').replace(":", "").replace("/", "")
+        input_name = variable.onnx_name.replace('_', '').replace(":", "").replace("/", "")
         if input_name and (input_name[0].isdigit() or
                            (not input_name.isalnum())):
             invalid_name.append(name)
@@ -1143,7 +1144,8 @@ def convert_topology(topology, model_name, doc_string, target_opset,
     if invalid_name:
         warnings.warn('Some input names are not compliant with ONNX naming '
                       'convention: %s' % invalid_name)
-    for name in topology.raw_model.input_names:
+    for variable in topology.raw_model._inputs:
+        name = variable.raw_name
         if name in other_inputs:
             container.add_input(other_inputs[name])
 

--- a/skl2onnx/common/_topology.py
+++ b/skl2onnx/common/_topology.py
@@ -1126,7 +1126,10 @@ def convert_topology(topology, model_name, doc_string, target_opset,
     for variable in topology.raw_model._inputs:
         name = variable.raw_name
         # Check input naming convention
-        input_name = variable.onnx_name.replace('_', '').replace(":", "").replace("/", "")
+        input_name = (
+            variable.onnx_name.replace('_', '')
+            .replace(":", "").replace("/", "")
+        )
         if input_name and (input_name[0].isdigit() or
                            (not input_name.isalnum())):
             invalid_name.append(name)

--- a/tests/test_raw_name.py
+++ b/tests/test_raw_name.py
@@ -9,7 +9,7 @@ from sklearn.datasets import load_iris
 from sklearn.linear_model import LogisticRegression
 
 
-class SpecialRawNameTest(unittest.TestCase):
+class RawNameTest(unittest.TestCase):
 
     _raw_names = (
         "float_input",

--- a/tests/test_raw_name.py
+++ b/tests/test_raw_name.py
@@ -14,6 +14,7 @@ class RawNameTest(unittest.TestCase):
     _raw_names = (
         "float_input",
         "float_input--",
+        "float_input("
     )
 
     @staticmethod

--- a/tests/test_raw_name.py
+++ b/tests/test_raw_name.py
@@ -14,7 +14,8 @@ class RawNameTest(unittest.TestCase):
     _raw_names = (
         "float_input",
         "float_input--",
-        "float_input("
+        "float_input(",
+        "float_input)",
     )
 
     @staticmethod

--- a/tests/test_raw_name.py
+++ b/tests/test_raw_name.py
@@ -39,15 +39,19 @@ class RawNameTest(unittest.TestCase):
 
     def test_raw_name(self):
         """
-        Assert that input raw names do not break the compilation of the graph and that
-        the ONNX model still produces correct predictions.
+        Assert that input raw names do not break the compilation
+        of the graph and that the ONNX model still produces
+        correct predictions.
         """
         X, y = self._load_data()
         clr = self._train_model(X, y)
         pred = clr.predict(X)
         for raw_name in self._raw_names:
             with self.subTest(raw_name=raw_name):
-                clr_onnx = convert_sklearn(clr, initial_types=self._get_initial_types(X, raw_name))
+                clr_onnx = convert_sklearn(
+                    clr,
+                    initial_types=self._get_initial_types(X, raw_name)
+                )
                 pred_onnx = self._predict(clr_onnx, X)
                 assert_almost_equal(
                     pred,

--- a/tests/test_raw_name.py
+++ b/tests/test_raw_name.py
@@ -20,7 +20,7 @@ class RawNameTest(unittest.TestCase):
     @staticmethod
     def _load_data():
         iris = load_iris()
-        return iris.data, iris.target
+        return iris.data[:, :2], iris.target
 
     @staticmethod
     def _train_model(X, y):

--- a/tests/test_special_raw_name.py
+++ b/tests/test_special_raw_name.py
@@ -1,0 +1,54 @@
+import unittest
+
+import numpy
+import onnxruntime as rt
+from numpy.testing import assert_almost_equal
+from skl2onnx import convert_sklearn
+from skl2onnx.common.data_types import FloatTensorType
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+
+
+class SpecialRawNameTest(unittest.TestCase):
+
+    _raw_names = (
+        "float_input",
+        "float_input--",
+    )
+
+    @staticmethod
+    def _load_data():
+        iris = load_iris()
+        return iris.data, iris.target
+
+    @staticmethod
+    def _train_model(X, y):
+        return LogisticRegression().fit(X, y)
+
+    @staticmethod
+    def _get_initial_types(X, raw_name):
+        return [(raw_name, FloatTensorType([None, X.shape[1]]))]
+
+    @staticmethod
+    def _predict(clr_onnx, X):
+        sess = rt.InferenceSession(clr_onnx.SerializeToString())
+        input_name = sess.get_inputs()[0].name
+        label_name = sess.get_outputs()[0].name
+        return sess.run([label_name], {input_name: X.astype(numpy.float32)})[0]
+
+    def test_raw_name(self):
+        """
+        Assert that input raw names do not break the compilation of the graph and that
+        the ONNX model still produces correct predictions.
+        """
+        X, y = self._load_data()
+        clr = self._train_model(X, y)
+        pred = clr.predict(X)
+        for raw_name in self._raw_names:
+            with self.subTest(raw_name=raw_name):
+                clr_onnx = convert_sklearn(clr, initial_types=self._get_initial_types(X, raw_name))
+                pred_onnx = self._predict(clr_onnx, X)
+                assert_almost_equal(
+                    pred,
+                    pred_onnx
+                )


### PR DESCRIPTION
We have a use case where we'd like to support certain special characters in the `variable.raw_name` (in our case: `(`, and `-`).

I noticed that there seems to be a small bug in the `convert_topology` function, where inputs are only added to the container if their `raw_name` is equal to their `onnx_name`. I believe I fixed that.

Also similar to https://github.com/onnx/sklearn-onnx/pull/687, I removed the check that raises an error when the `raw_name` contains a `(`. Again, we have a use case where being able to have `(` as part of the raw name would be extremely useful and I don't see a reason why this would break the ONNX graph. If this is an oversight on my end, please let me know. 🙂

I also added some test cases to make sure everything is working as intended.

If this contribution gets accepted, I would suggest to close https://github.com/onnx/sklearn-onnx/pull/696.