### PR TITLE
Remove option ZipMap for MultiOutputClassifier

### DIFF
--- a/skl2onnx/_parse.py
+++ b/skl2onnx/_parse.py
@@ -18,6 +18,7 @@ from sklearn.linear_model import BayesianRidge
 from sklearn.model_selection import GridSearchCV
 from sklearn.neighbors import NearestNeighbors
 from sklearn.mixture import GaussianMixture, BayesianGaussianMixture
+from sklearn.multioutput import MultiOutputClassifier
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.pipeline import Pipeline
 from sklearn.svm import LinearSVC, NuSVC, SVC
@@ -672,6 +673,7 @@ def build_sklearn_parsers_map():
         BayesianRidge: _parse_sklearn_bayesian_ridge,
         GaussianProcessRegressor: _parse_sklearn_gaussian_process,
         GridSearchCV: _parse_sklearn_grid_search_cv,
+        MultiOutputClassifier: _parse_sklearn_simple_model,
     }
     if ColumnTransformer is not None:
         map_parser[ColumnTransformer] = _parse_sklearn_column_transformer

--- a/skl2onnx/_supported_operators.py
+++ b/skl2onnx/_supported_operators.py
@@ -237,7 +237,6 @@ sklearn_classifier_list = list(filter(lambda m: m is not None, [
     LogisticRegressionCV,
     MLPClassifier,
     MultinomialNB,
-    MultiOutputClassifier,
     NuSVC,
     OneVsRestClassifier,
     PassiveAggressiveClassifier,

--- a/skl2onnx/operator_converters/multioutput.py
+++ b/skl2onnx/operator_converters/multioutput.py
@@ -36,8 +36,14 @@ def convert_multi_output_classifier_converter(
     op_version = container.target_opset
     op = operator.raw_operator
     inp = operator.inputs[0]
+    options = scope.get_options(op)
+    if options.get('nocl', True):
+        options = options.copy()
+    else:
+        options = {}
+    options.update({'zipmap': False})
     y_list = [OnnxSubEstimator(sub, inp, op_version=op_version,
-                               options={'zipmap': False})
+                               options=options)
               for sub in op.estimators_]
 
     # labels
@@ -65,4 +71,4 @@ register_converter('SklearnMultiOutputRegressor',
                    convert_multi_output_regressor_converter)
 register_converter('SklearnMultiOutputClassifier',
                    convert_multi_output_classifier_converter,
-                   options={'zipmap': [False], 'nocl': [False, True]})
+                   options={'nocl': [False, True]})


### PR DESCRIPTION
MultiOutputClassifier is a classifier but it does not follow the same pattern as the other classifiers. Options zipmap is disabled for this model. probabilities are always returned as a tensor.