### PR TITLE
Use Sequence instead of Tensor for MultiOutputClassifier probabilities

### DIFF
--- a/skl2onnx/operator_converters/multioutput.py
+++ b/skl2onnx/operator_converters/multioutput.py
@@ -5,7 +5,12 @@ from ..common._registration import register_converter
 from ..common._topology import Scope, Operator
 from ..common._container import ModelComponentContainer
 from ..algebra.onnx_ops import (
-    OnnxConcat, OnnxReshape, OnnxIdentity, OnnxSequenceConstruct)
+    OnnxConcat, OnnxReshape, OnnxIdentity)
+try:
+    from ..algebra.onnx_ops import OnnxSequenceConstruct
+except ImportError:
+    # Available since opset 11
+    OnnxSequenceConstruct = None
 from ..algebra.onnx_operator import OnnxSubEstimator
 
 
@@ -34,6 +39,10 @@ def convert_multi_output_classifier_converter(
     """
     Converts a *MultiOutputClassifier* into *ONNX* format.
     """
+    if OnnxSequenceConstruct is None:
+        raise RuntimeError(
+            "This converter requires opset>=11.")
+    op_version = container.target_opset
     op_version = container.target_opset
     op = operator.raw_operator
     inp = operator.inputs[0]

--- a/skl2onnx/operator_converters/multioutput.py
+++ b/skl2onnx/operator_converters/multioutput.py
@@ -4,7 +4,8 @@ import numpy as np
 from ..common._registration import register_converter
 from ..common._topology import Scope, Operator
 from ..common._container import ModelComponentContainer
-from ..algebra.onnx_ops import OnnxConcat, OnnxReshape, OnnxIdentity
+from ..algebra.onnx_ops import (
+    OnnxConcat, OnnxReshape, OnnxIdentity, OnnxSequenceConstruct)
 from ..algebra.onnx_operator import OnnxSubEstimator
 
 
@@ -59,10 +60,8 @@ def convert_multi_output_classifier_converter(
     proba_list = [OnnxIdentity(y[1], op_version=op_version)
                   for y in y_list]
 
-    proba = OnnxReshape(
-        OnnxConcat(*proba_list, axis=1, op_version=op_version),
-        np.array([-1, len(op.estimators_), 2], dtype=np.int64),
-        op_version=op_version,
+    proba = OnnxSequenceConstruct(
+        *proba_list, op_version=op_version,
         output_names=[operator.outputs[1]])
     proba.add_to(scope=scope, container=container)
 

--- a/skl2onnx/shape_calculators/multioutput.py
+++ b/skl2onnx/shape_calculators/multioutput.py
@@ -2,12 +2,16 @@
 
 
 from ..common._registration import register_shape_calculator
+from ..common.utils import check_input_and_output_numbers
+from ..common.data_types import SequenceType
 
 _stack = []
 
 
 def multioutput_regressor_shape_calculator(operator):
     """Shape calculator for MultiOutputRegressor"""
+    check_input_and_output_numbers(
+        operator, input_count_range=1, output_count_range=1)
     i = operator.inputs[0]
     o = operator.outputs[0]
     N = i.get_first_dimension()
@@ -17,12 +21,17 @@ def multioutput_regressor_shape_calculator(operator):
 
 def multioutput_classifier_shape_calculator(operator):
     """Shape calculator for MultiOutputClassifier"""
+    check_input_and_output_numbers(
+        operator, input_count_range=1, output_count_range=2)
+    if not isinstance(operator.outputs[1].type, SequenceType):
+        raise RuntimeError(
+            "Probabilites should be a sequence not %r."
+            "" % operator.outputs[1].type)
     i = operator.inputs[0]
     outputs = operator.outputs
     N = i.get_first_dimension()
     C = len(operator.raw_operator.estimators_)
     outputs[0].type.shape = [N, C]
-    outputs[1].type.shape = [N, C, 2]
 
 
 register_shape_calculator('SklearnMultiOutputRegressor',

--- a/tests/test_sklearn_multi_output.py
+++ b/tests/test_sklearn_multi_output.py
@@ -44,9 +44,11 @@ class TestMultiOutputConverter(unittest.TestCase):
         sess = InferenceSession(onx.SerializeToString())
         res = sess.run(None, {'X': X})
         exp_lab = clf.predict(X)
-        exp_prb = numpy.transpose(clf.predict_proba(X), (1, 0, 2))
+        exp_prb = clf.predict_proba(X)
         assert_almost_equal(exp_lab, res[0])
-        assert_almost_equal(exp_prb, res[1], decimal=5)
+        self.assertEqual(len(exp_prb), len(res[1]))
+        for e, g in zip(exp_prb, res[1]):
+            assert_almost_equal(e, g, decimal=5)
 
         # check option nocl=True
         onx = to_onnx(clf, X[:1], target_opset=TARGET_OPSET,
@@ -56,9 +58,11 @@ class TestMultiOutputConverter(unittest.TestCase):
         sess = InferenceSession(onx.SerializeToString())
         res = sess.run(None, {'X': X})
         exp_lab = clf.predict(X)
-        exp_prb = numpy.transpose(clf.predict_proba(X), (1, 0, 2))
+        exp_prb = clf.predict_proba(X)
         assert_almost_equal(exp_lab, res[0])
-        assert_almost_equal(exp_prb, res[1], decimal=5)
+        self.assertEqual(len(exp_prb), len(res[1]))
+        for e, g in zip(exp_prb, res[1]):
+            assert_almost_equal(e, g, decimal=5)
 
         # check option nocl=False
         onx = to_onnx(clf, X[:1], target_opset=TARGET_OPSET,
@@ -68,9 +72,11 @@ class TestMultiOutputConverter(unittest.TestCase):
         sess = InferenceSession(onx.SerializeToString())
         res = sess.run(None, {'X': X})
         exp_lab = clf.predict(X)
-        exp_prb = numpy.transpose(clf.predict_proba(X), (1, 0, 2))
+        exp_prb = clf.predict_proba(X)
         assert_almost_equal(exp_lab, res[0])
-        assert_almost_equal(exp_prb, res[1], decimal=5)
+        self.assertEqual(len(exp_prb), len(res[1]))
+        for e, g in zip(exp_prb, res[1]):
+            assert_almost_equal(e, g, decimal=5)
 
 
 if __name__ == "__main__":

--- a/tests/test_sklearn_multi_output.py
+++ b/tests/test_sklearn_multi_output.py
@@ -31,6 +31,8 @@ class TestMultiOutputConverter(unittest.TestCase):
             X.astype(numpy.float32), clf, onx,
             basename="SklearnMultiOutputRegressor")
 
+    @unittest.skipIf(TARGET_OPSET<11,
+                     reason="SequenceConstruct not available.")
     def test_multi_output_classifier(self):
         X, y = make_multilabel_classification(n_classes=3, random_state=0)
         X = X.astype(numpy.float32)

--- a/tests/test_sklearn_multi_output.py
+++ b/tests/test_sklearn_multi_output.py
@@ -31,7 +31,7 @@ class TestMultiOutputConverter(unittest.TestCase):
             X.astype(numpy.float32), clf, onx,
             basename="SklearnMultiOutputRegressor")
 
-    @unittest.skipIf(TARGET_OPSET<11,
+    @unittest.skipIf(TARGET_OPSET < 11,
                      reason="SequenceConstruct not available.")
     def test_multi_output_classifier(self):
         X, y = make_multilabel_classification(n_classes=3, random_state=0)

--- a/tests/test_sklearn_nearest_neighbour_converter.py
+++ b/tests/test_sklearn_nearest_neighbour_converter.py
@@ -209,7 +209,7 @@ class TestNearestNeighbourConverter(unittest.TestCase):
             model, model_onnx,
             basename="SklearnRadiusNeighborsRegressor64")
         dump_data_and_model(
-            (X + 0.1).astype(numpy.float64)[:7],
+            (X + 10.).astype(numpy.float64)[:7],
             model, model_onnx,
             basename="SklearnRadiusNeighborsRegressor64")
 

--- a/tests/test_sklearn_pipeline.py
+++ b/tests/test_sklearn_pipeline.py
@@ -673,6 +673,8 @@ class TestSklearnPipeline(unittest.TestCase):
         assert_almost_equal(expected_proba, got[1])
         assert_almost_equal(expected_label, got[0])
 
+    @unittest.skipIf(TARGET_OPSET < 11,
+                     reason="SequenceConstruct not available")
     @ignore_warnings(category=(FutureWarning, UserWarning))
     def test_pipeline_pipeline_rf(self):
         cat_feat = ['A', 'B']
@@ -719,6 +721,8 @@ class TestSklearnPipeline(unittest.TestCase):
             assert_almost_equal(e, g, decimal=5)
         assert_almost_equal(expected_label, got[0])
 
+    @unittest.skipIf(TARGET_OPSET < 11,
+                     reason="SequenceConstruct not available")
     def test_issue_712(self):
         dfx = pandas.DataFrame(
             {'CAT1': ['985332', '985333', '985334', '985335', '985336'],

--- a/tests/test_sklearn_pipeline.py
+++ b/tests/test_sklearn_pipeline.py
@@ -749,7 +749,7 @@ class TestSklearnPipeline(unittest.TestCase):
         inputs = {'CAT1': dfx['CAT1'].values.reshape((-1, 1)),
                   'CAT2': dfx['CAT2'].values.reshape((-1, 1)),
                   'TEXT': dfx['TEXT'].values.reshape((-1, 1))}
-        onx = to_onnx(rf_clf, dfx)
+        onx = to_onnx(rf_clf, dfx, target_opset=TARGET_OPSET)
         sess = InferenceSession(onx.SerializeToString())
 
         got = sess.run(None, inputs)

--- a/tests/test_sklearn_pipeline.py
+++ b/tests/test_sklearn_pipeline.py
@@ -38,7 +38,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer, CountVectorizer
 from sklearn.ensemble import VotingClassifier, RandomForestClassifier
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.svm import SVC
-from skl2onnx import convert_sklearn
+from skl2onnx import convert_sklearn, to_onnx
 from skl2onnx.common.data_types import (
     FloatTensorType,
     Int64TensorType,
@@ -714,9 +714,49 @@ class TestSklearnPipeline(unittest.TestCase):
         sess = InferenceSession(model_onnx.SerializeToString())
         got = sess.run(None, {'A': data[:, :1], 'B': data[:, 1:2],
                               'TEXT': data[:, 2:]})
-        assert_almost_equal(
-            numpy.transpose(expected_proba, (1, 0, 2)), got[1])
+        self.assertEqual(len(expected_proba), len(got[1]))
+        for e, g in zip(expected_proba, got[1]):
+            assert_almost_equal(e, g, decimal=5)
         assert_almost_equal(expected_label, got[0])
+
+    def test_issue_712(self):
+        dfx = pandas.DataFrame(
+            {'CAT1': ['985332', '985333', '985334', '985335', '985336'],
+             'CAT2': ['1985332', '1985333', '1985334', '1985335', '1985336'],
+             'TEXT': ["abc abc", "abc def", "def ghj", "abcdef", "abc ii"]})
+        dfy = pandas.DataFrame(
+            {'REAL': [5, 6, 7, 6, 5],
+             'CATY': [0, 1, 0, 1, 0]})
+
+        cat_features = ['CAT1', 'CAT2']
+        categorical_transformer = OneHotEncoder(handle_unknown='ignore')
+        textual_feature = 'TEXT'
+        count_vect_transformer = Pipeline(steps=[
+            ('count_vect', CountVectorizer(
+                max_df=0.8, min_df=0.05, max_features=1000))])
+        preprocessor = ColumnTransformer(
+            transformers=[
+                ('cat_transform', categorical_transformer, cat_features),
+                ('count_vector', count_vect_transformer, textual_feature)])
+        model_RF = RandomForestClassifier(random_state=42, max_depth=50)
+        rf_clf = Pipeline(steps=[
+            ('preprocessor', preprocessor),
+            ('classifier', MultiOutputClassifier(estimator=model_RF))])
+        rf_clf.fit(dfx, dfy)
+        expected_label = rf_clf.predict(dfx)
+        expected_proba = rf_clf.predict_proba(dfx)
+
+        inputs = {'CAT1': dfx['CAT1'].values.reshape((-1, 1)),
+                  'CAT2': dfx['CAT2'].values.reshape((-1, 1)),
+                  'TEXT': dfx['TEXT'].values.reshape((-1, 1))}
+        onx = to_onnx(rf_clf, dfx)
+        sess = InferenceSession(onx.SerializeToString())
+
+        got = sess.run(None, inputs)
+        assert_almost_equal(expected_label, got[0])
+        self.assertEqual(len(expected_proba), len(got[1]))
+        for e, g in zip(expected_proba, got[1]):
+            assert_almost_equal(e, g, decimal=5)
 
 
 if __name__ == "__main__":
@@ -724,5 +764,4 @@ if __name__ == "__main__":
     # logger = logging.getLogger('skl2onnx')
     # logger.setLevel(logging.DEBUG)
     # logging.basicConfig(level=logging.DEBUG)
-    # TestSklearnPipeline().test_pipeline_pipeline_rf()
     unittest.main()


### PR DESCRIPTION
Fixes #712.

The former version was working only for multi binary classification. The new version uses a Sequence and not a 3D tensor to hold the output probilities. It follows scikit-learn API.