### PR TITLE
Add parameter naming to rename all intermediate results

### DIFF
--- a/docs/tutorial/plot_abegin_convert_pipeline.py
+++ b/docs/tutorial/plot_abegin_convert_pipeline.py
@@ -39,8 +39,8 @@ X, y = load_diabetes(return_X_y=True)
 X_train, X_test, y_train, y_test = train_test_split(X, y)
 
 # Train classifiers
-reg1 = GradientBoostingRegressor(random_state=1)
-reg2 = RandomForestRegressor(random_state=1)
+reg1 = GradientBoostingRegressor(random_state=1, n_estimators=5)
+reg2 = RandomForestRegressor(random_state=1, n_estimators=5)
 reg3 = LinearRegression()
 
 ereg = Pipeline(steps=[

--- a/docs/tutorial/plot_gconverting.py
+++ b/docs/tutorial/plot_gconverting.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Modify the ONNX graph
+=====================
+
+This example shows how to change the default ONNX graph such as
+renaming the inputs or outputs names.
+
+.. contents::
+    :local:
+
+Basic example
++++++++++++++
+
+"""
+import numpy
+from onnxruntime import InferenceSession
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+from sklearn.linear_model import LogisticRegression
+from skl2onnx.common.data_types import FloatTensorType, Int64TensorType
+from skl2onnx import to_onnx
+
+iris = load_iris()
+X, y = iris.data, iris.target
+X = X.astype(numpy.float32)
+X_train, X_test, y_train, y_test = train_test_split(X, y)
+
+clr = LogisticRegression(solver="liblinear")
+clr.fit(X_train, y_train)
+
+
+onx = to_onnx(clr, X, options={'zipmap': False})
+
+sess = InferenceSession(onx.SerializeToString())
+input_names = [i.name for i in sess.get_inputs()]
+output_names = [o.name for o in sess.get_outputs()]
+print("inputs=%r, outputs=%r" % (input_names, output_names))
+print(sess.run(None, {input_names[0]: X_test[:2]}))
+
+
+####################################
+# Changes the input names
+# +++++++++++++++++++++++
+#
+# It is possible to change the input name by using the
+# parameter *initial_types*. However, the user must specify the input
+# types as well.
+
+onx = to_onnx(clr, X, options={'zipmap': False},
+              initial_types=[('X56', FloatTensorType([None, X.shape[1]]))])
+
+sess = InferenceSession(onx.SerializeToString())
+input_names = [i.name for i in sess.get_inputs()]
+output_names = [o.name for o in sess.get_outputs()]
+print("inputs=%r, outputs=%r" % (input_names, output_names))
+print(sess.run(None, {input_names[0]: X_test[:2]}))
+
+
+####################################
+# Changes the output names
+# ++++++++++++++++++++++++
+#
+# It is possible to change the input name by using the
+# parameter *final_types*.
+
+onx = to_onnx(clr, X, options={'zipmap': False},
+              final_types=[('L', Int64TensorType([None])),
+                           ('P', FloatTensorType([None, 3]))])
+
+sess = InferenceSession(onx.SerializeToString())
+input_names = [i.name for i in sess.get_inputs()]
+output_names = [o.name for o in sess.get_outputs()]
+print("inputs=%r, outputs=%r" % (input_names, output_names))
+print(sess.run(None, {input_names[0]: X_test[:2]}))

--- a/docs/tutorial/plot_gconverting.py
+++ b/docs/tutorial/plot_gconverting.py
@@ -74,3 +74,30 @@ input_names = [i.name for i in sess.get_inputs()]
 output_names = [o.name for o in sess.get_outputs()]
 print("inputs=%r, outputs=%r" % (input_names, output_names))
 print(sess.run(None, {input_names[0]: X_test[:2]}))
+
+####################################
+# Renaming intermediate results
+# +++++++++++++++++++++++++++++
+#
+# It is possible to rename intermediate results by using a prefix
+# or by using a function. The result will be post-processed in order
+# to unique names. It does not impact the graph inputs or outputs.
+
+
+def rename_results(proposed_name, existing_names):
+    result = "_" + proposed_name.upper()
+    while result in existing_names:
+        result += "A"
+    print("changed %r into %r." % (proposed_name, result))
+    return result
+
+
+onx = to_onnx(clr, X, options={'zipmap': False},
+              naming=rename_results)
+
+sess = InferenceSession(onx.SerializeToString())
+input_names = [i.name for i in sess.get_inputs()]
+output_names = [o.name for o in sess.get_outputs()]
+print("inputs=%r, outputs=%r" % (input_names, output_names))
+print(sess.run(None, {input_names[0]: X_test[:2]}))
+

--- a/docs/tutorial_1_simple.rst
+++ b/docs/tutorial_1_simple.rst
@@ -25,4 +25,5 @@ used in the ONNX graph.
     auto_tutorial/plot_fbegin_investigate
     auto_tutorial/plot_gbegin_cst
     auto_tutorial/plot_gbegin_dataframe
+    auto_tutorial/plot_gconverting
     auto_tutorial/plot_gbegin_transfer_learning

--- a/skl2onnx/_parse.py
+++ b/skl2onnx/_parse.py
@@ -637,7 +637,8 @@ def parse_sklearn_model(model, initial_types=None, target_opset=None,
                         custom_shape_calculators=None,
                         custom_parsers=None,
                         options=None, white_op=None,
-                        black_op=None, final_types=None):
+                        black_op=None, final_types=None,
+                        naming=None):
     """
     Puts *scikit-learn* object into an abstract container so that
     our framework can work seamlessly on models created
@@ -666,7 +667,15 @@ def parse_sklearn_model(model, initial_types=None, target_opset=None,
     :param final_types: a python list. Works the same way as initial_types
         but not mandatory, it is used to overwrites the type
         (if type is not None) and the name of every output.
+    :param naming: the user may want to change the way intermediate
+        are named, this parameter can be a string (a prefix) or a
+        function, which signature is the following:
+        `get_name(name, existing_names)`, the library will then
+        check this name is unique and modify it if not
     :return: :class:`Topology <skl2onnx.common._topology.Topology>`
+
+    .. versionchanged:: 1.10.0
+        Parameter *naming* was added.
     """
     options = _process_options(model, options)
 
@@ -685,9 +694,7 @@ def parse_sklearn_model(model, initial_types=None, target_opset=None,
             aliases=sklearn_operator_name_map))
 
     # Declare an object to provide variables' and operators' naming mechanism.
-    # In contrast to CoreML, one global scope
-    # is enough for parsing scikit-learn models.
-    scope = topology.declare_scope('__root__', options=options)
+    scope = topology.declare_scope('__root__', options=options, naming=naming)
     inputs = scope.input_variables
 
     # The object raw_model_container is a part of the topology

--- a/skl2onnx/convert.py
+++ b/skl2onnx/convert.py
@@ -18,7 +18,7 @@ def convert_sklearn(model, name=None, initial_types=None, doc_string='',
                     custom_parsers=None, options=None,
                     intermediate=False,
                     white_op=None, black_op=None, final_types=None,
-                    dtype=None, verbose=0):
+                    dtype=None, naming=None, verbose=0):
     """
     This function produces an equivalent
     ONNX model of the given scikit-learn model.
@@ -59,7 +59,7 @@ def convert_sklearn(model, name=None, initial_types=None, doc_string='',
     :param options: specific options given to converters
         (see :ref:`l-conv-options`)
     :param intermediate: if True, the function returns the
-        converted model and , and :class:`Topology`,
+        converted model and the instance of :class:`Topology` used,
         it returns the converted model otherwise
     :param white_op: white list of ONNX nodes allowed
         while converting a pipeline,
@@ -74,6 +74,11 @@ def convert_sklearn(model, name=None, initial_types=None, doc_string='',
         now inferred from input types,
         converters may add operators Cast to switch
         to double when it is necessary
+    :param naming: the user may want to change the way intermediate
+        are named, this parameter can be a string (a prefix) or a
+        function, which signature is the following:
+        `get_name(name, existing_names)`, the library will then
+        check this name is unique and modify it if not
     :param verbose: display progress while converting a model
     :return: An ONNX model (type: ModelProto) which is
         equivalent to the input scikit-learn model
@@ -142,11 +147,8 @@ def convert_sklearn(model, name=None, initial_types=None, doc_string='',
 
     It is used in example :ref:`l-example-tfidfvectorizer`.
 
-    .. versionchanged:: 1.7
-        Parameter `target_opset`, if not specified, is now set to
-        the latest tested opset returned by
-        :py:func:`skl2onnx.get_latest_tested_opset_version` and
-        not the version of the *onnx* package.
+    .. versionchanged:: 1.10.0
+        Parameter *naming* was added.
     """
     if initial_types is None:
         if hasattr(model, 'infer_initial_types'):
@@ -173,7 +175,7 @@ def convert_sklearn(model, name=None, initial_types=None, doc_string='',
         model, initial_types, target_opset, custom_conversion_functions,
         custom_shape_calculators, custom_parsers, options=options,
         white_op=white_op, black_op=black_op,
-        final_types=final_types)
+        final_types=final_types, naming=naming)
 
     # Convert our Topology object into ONNX. The outcome is an ONNX model.
     options = _process_options(model, options)
@@ -207,7 +209,7 @@ def convert_sklearn(model, name=None, initial_types=None, doc_string='',
 def to_onnx(model, X=None, name=None, initial_types=None,
             target_opset=None, options=None,
             white_op=None, black_op=None, final_types=None,
-            dtype=None, verbose=0):
+            dtype=None, naming=None, verbose=0):
     """
     Calls :func:`convert_sklearn` with simplified parameters.
 
@@ -230,12 +232,20 @@ def to_onnx(model, X=None, name=None, initial_types=None,
     :param dtype: removed in version 1.7.5, dtype is now inferred from
         input types, converters may add operators Cast to switch to
         double when it is necessary
+    :param naming: the user may want to change the way intermediate
+        are named, this parameter can be a string (a prefix) or a
+        function, which signature is the following:
+        `get_name(name, existing_names)`, the library will then
+        check this name is unique and modify it if not
     :param verbose: display progress while converting a model
     :return: converted model
 
     This function checks if the model inherits from class
     :class:`OnnxOperatorMixin`, it calls method *to_onnx*
     in that case otherwise it calls :func:`convert_sklearn`.
+
+    .. versionchanged:: 1.10.0
+        Parameter *naming* was added.
     """
     from .algebra.onnx_operator_mixin import OnnxOperatorMixin
     from .algebra.type_helper import guess_initial_types
@@ -253,7 +263,7 @@ def to_onnx(model, X=None, name=None, initial_types=None,
                            name=name, options=options,
                            white_op=white_op, black_op=black_op,
                            final_types=final_types, dtype=dtype,
-                           verbose=verbose)
+                           verbose=verbose, naming=naming)
 
 
 def wrap_as_onnx_mixin(model, target_opset=None):

--- a/tests/test_utils/tests_helper.py
+++ b/tests/test_utils/tests_helper.py
@@ -450,8 +450,7 @@ def convert_model(model, name, input_types, target_opset=None):
     """
     Runs the appropriate conversion method.
 
-    :param model: model, *scikit-learn*, *keras*,
-         or *coremltools* object
+    :param model: model created with *scikit-learn*
     :return: *onnx* model
     """
     from skl2onnx import convert_sklearn


### PR DESCRIPTION
Add also one example into the documentation about initial_types, final_types, naming.