### PR TITLE
Documentation: Ways to create own converters.

### DIFF
--- a/docs/tutorial/plot_jcustom_syntax.py
+++ b/docs/tutorial/plot_jcustom_syntax.py
@@ -7,11 +7,11 @@ Two ways to implement a converter
 .. index:: syntax
 
 There are two ways to write a converter. The first one
-is very verbose (see `ada_boost.py <https://github.com/onnx/
-sklearn-onnx/blob/master/skl2onnx/operator_converters/ada_boost.py>`_
-for an example). The other is less verbose and easier to understand
+is less verbose and easier to understand
 (see `k_means.py <https://github.com/onnx/sklearn-onnx/blob/
-master/skl2onnx/operator_converters/k_means.py>`_).
+master/skl2onnx/operator_converters/k_means.py>`_). The other is very verbose (see `ada_boost.py <https://github.com/onnx/
+sklearn-onnx/blob/master/skl2onnx/operator_converters/ada_boost.py>`_
+for an example).
 
 The first way is used in :ref:`l-plot-custom-converter`.
 This one demonstrates the second way which is usually the one


### PR DESCRIPTION
The documentation was inconsistent with the mentioned order of the two ways to create a converter.