### PR TITLE
LocalOutlierFactor n_neighbors bugfix

### DIFF
--- a/skl2onnx/operator_converters/local_outlier_factor.py
+++ b/skl2onnx/operator_converters/local_outlier_factor.py
@@ -35,7 +35,7 @@ def convert_sklearn_local_outlier_factor(
     metric = (op.effective_metric_ if hasattr(op, 'effective_metric_') else
               op.metric)
     neighb = op._fit_X.astype(dtype)
-    k = op.n_neighbors
+    k = op.n_neighbors_
     kwargs = {}
     if op.p != 2:
         if options['optim'] == 'cdist':

--- a/tests/test_sklearn_local_outlier_factor.py
+++ b/tests/test_sklearn_local_outlier_factor.py
@@ -53,7 +53,7 @@ class TestSklearnLocalOutlierForest(unittest.TestCase):
         assert_almost_equal(expected_decif, got[1].ravel())
 
     @unittest.skipIf(LocalOutlierFactor is None, reason="old scikit-learn")
-    def test_local_outlier_factor_n_neighbors_greater_than_n_observations(self):
+    def test_local_outlier_factor_n_neighbors_greater_than_observations(self):
         lof = LocalOutlierFactor(n_neighbors=25, novelty=True)
         data = np.array([[-1.1, -1.2], [0.3, 0.2],
                          [0.5, 0.4], [100., 99.]], dtype=np.float32)

--- a/tests/test_sklearn_local_outlier_factor.py
+++ b/tests/test_sklearn_local_outlier_factor.py
@@ -72,7 +72,7 @@ class TestSklearnLocalOutlierForest(unittest.TestCase):
         expected_label = lof.predict(data)
         expected_decif = lof.decision_function(data)
         assert_almost_equal(expected_label, got[0].ravel())
-        assert_almost_equal(expected_decif, got[1].ravel())
+        assert_almost_equal(expected_decif, got[1].ravel(), decimal=5)
 
     @unittest.skipIf(LocalOutlierFactor is None, reason="old scikit-learn")
     @unittest.skipIf(StrictVersion(ort_version) < StrictVersion("1.5.0"),


### PR DESCRIPTION
This PR tests for and fixes a bug that arises when the n_neighbors parameter is set higher than the number of training observations:

ERROR: test_local_outlier_factor_n_neighbors_greater_than_n_observations (__main__.TestSklearnLocalOutlierForest)

Traceback (most recent call last):
  File "/sklearn-onnx/tests/test_sklearn_local_outlier_factor.py", line 67, in test_local_outlier_factor_n_neighbors_greater_than_n_observations
    sess = InferenceSession(model_onnx.SerializeToString())
  File "/sklearn-onnx/lib/python3.9/site-packages/onnxruntime/capi/onnxruntime_inference_collection.py", line 335, in __init__
    self._create_inference_session(providers, provider_options, disabled_optimizers)
  File "/sklearn-onnx/lib/python3.9/site-packages/onnxruntime/capi/onnxruntime_inference_collection.py", line 370, in _create_inference_session
    sess = C.InferenceSession(session_options, self._model_bytes, False, self._read_config_from_model)
onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Node (To_TopK) Op (TopK) [ShapeInferenceError] Axis has less than the requested k elements.