### PR TITLE
Fix unit test with unfitted models, fix PLSRegression 1.1

### DIFF
--- a/docs/tutorial/plot_gbegin_transfer_learning.py
+++ b/docs/tutorial/plot_gbegin_transfer_learning.py
@@ -62,7 +62,7 @@ def download_file(url, name, min_size):
 
 
 model_name = "squeezenet1.1-7.onnx"
-url_name = ("https://github.com/onnx/models/raw/master/vision/"
+url_name = ("https://github.com/onnx/models/raw/main/vision/"
             "classification/squeezenet/model")
 url_name += "/" + model_name
 try:

--- a/skl2onnx/operator_converters/cross_decomposition.py
+++ b/skl2onnx/operator_converters/cross_decomposition.py
@@ -26,14 +26,16 @@ def convert_pls_regression(scope: Scope, operator: Operator,
     if type(X.type) == Int64TensorType:
         X = OnnxCast(X, to=proto_dtype, op_version=opv)
 
+    coefs = op.x_mean_ if hasattr(op, 'x_mean_') else op._x_mean
+    std = op.x_std_ if hasattr(op, 'x_std_') else op._x_std
+    ym = op.y_mean_ if hasattr(op, 'x_mean_') else op._y_mean
+
     norm_x = OnnxDiv(
-        OnnxSub(X, op.x_mean_.astype(dtype),
-                op_version=opv),
-        op.x_std_.astype(dtype),
-        op_version=opv)
+        OnnxSub(X, coefs.astype(dtype), op_version=opv),
+        std.astype(dtype), op_version=opv)
     dot = OnnxMatMul(norm_x, op.coef_.astype(dtype),
                      op_version=opv)
-    pred = OnnxAdd(dot, op.y_mean_.astype(dtype),
+    pred = OnnxAdd(dot, ym.astype(dtype),
                    op_version=opv, output_names=operator.outputs)
     pred.add_to(scope, container)
 

--- a/tests/test_sklearn_binarizer_converter.py
+++ b/tests/test_sklearn_binarizer_converter.py
@@ -18,6 +18,7 @@ class TestSklearnBinarizer(unittest.TestCase):
                          [2., 0., 0.],
                          [0., 1., -1.]], dtype=np.float32)
         model = Binarizer(threshold=0.5)
+        model.fit(data)
         model_onnx = convert_sklearn(
             model, "scikit-learn binarizer",
             [("input", FloatTensorType(data.shape))],

--- a/tests/test_sklearn_double_tensor_type_tr.py
+++ b/tests/test_sklearn_double_tensor_type_tr.py
@@ -394,6 +394,7 @@ class TestSklearnDoubleTensorTypeTransformer(unittest.TestCase):
                          [2., 0., 0.],
                          [0., 1., -1.]], dtype=np.float64)
         model = Binarizer(threshold=0.5)
+        model.fit(data)
         model_onnx = convert_sklearn(
             model, "scikit-learn binarizer",
             [("input", DoubleTensorType(data.shape))],

--- a/tests/test_sklearn_normalizer_converter.py
+++ b/tests/test_sklearn_normalizer_converter.py
@@ -15,6 +15,8 @@ from test_utils import dump_data_and_model, TARGET_OPSET
 class TestSklearnNormalizerConverter(unittest.TestCase):
     def test_model_normalizer(self):
         model = Normalizer(norm="l2")
+        x = numpy.random.randn(10, 1).astype(numpy.int64)
+        model.fit(x)
         model_onnx = convert_sklearn(
             model, "scikit-learn normalizer",
             [("input", Int64TensorType([None, 1]))],
@@ -24,6 +26,8 @@ class TestSklearnNormalizerConverter(unittest.TestCase):
 
     def test_model_normalizer_blackop(self):
         model = Normalizer(norm="l2")
+        x = numpy.random.randn(10, 3).astype(numpy.float32)
+        model.fit(x)
         model_onnx = convert_sklearn(
             model, "scikit-learn normalizer",
             [("input", FloatTensorType([None, 3]))],
@@ -37,6 +41,8 @@ class TestSklearnNormalizerConverter(unittest.TestCase):
 
     def test_model_normalizer_float_l1(self):
         model = Normalizer(norm="l1")
+        x = numpy.random.randn(10, 3).astype(numpy.float32)
+        model.fit(x)
         model_onnx = convert_sklearn(
             model, "scikit-learn normalizer",
             [("input", FloatTensorType([None, 3]))],
@@ -50,6 +56,8 @@ class TestSklearnNormalizerConverter(unittest.TestCase):
 
     def test_model_normalizer_float_l2(self):
         model = Normalizer(norm="l2")
+        x = numpy.random.randn(10, 3).astype(numpy.float32)
+        model.fit(x)
         model_onnx = convert_sklearn(
             model, "scikit-learn normalizer",
             [("input", FloatTensorType([None, 3]))],
@@ -63,6 +71,8 @@ class TestSklearnNormalizerConverter(unittest.TestCase):
 
     def test_model_normalizer_double_l1(self):
         model = Normalizer(norm="l1")
+        x = numpy.random.randn(10, 3).astype(numpy.float64)
+        model.fit(x)
         model_onnx = convert_sklearn(
             model, "scikit-learn normalizer",
             [("input", DoubleTensorType([None, 3]))],
@@ -75,6 +85,8 @@ class TestSklearnNormalizerConverter(unittest.TestCase):
 
     def test_model_normalizer_double_l2(self):
         model = Normalizer(norm="l2")
+        x = numpy.random.randn(10, 3).astype(numpy.float64)
+        model.fit(x)
         model_onnx = convert_sklearn(
             model, "scikit-learn normalizer",
             [("input", DoubleTensorType([None, 3]))],
@@ -87,6 +99,8 @@ class TestSklearnNormalizerConverter(unittest.TestCase):
 
     def test_model_normalizer_float_noshape(self):
         model = Normalizer(norm="l2")
+        x = numpy.random.randn(10, 3).astype(numpy.float32)
+        model.fit(x)
         model_onnx = convert_sklearn(
             model, "scikit-learn normalizer",
             [("input", FloatTensorType([]))],

--- a/tests/test_sklearn_pls_regression.py
+++ b/tests/test_sklearn_pls_regression.py
@@ -34,9 +34,7 @@ class TestSklearnPLSRegressionConverters(unittest.TestCase):
         self.assertTrue(model_onnx is not None)
         dump_data_and_model(
             X, pls2, model_onnx, methods=['predict'],
-            basename="SklearnPLSRegression",
-            allow_failure="StrictVersion("
-            "onnxruntime.__version__)<= StrictVersion('0.2.1')")
+            basename="SklearnPLSRegression")
 
     @unittest.skipIf(not onnx_built_with_ml(),
                      reason="Requires ONNX-ML extension.")
@@ -56,9 +54,7 @@ class TestSklearnPLSRegressionConverters(unittest.TestCase):
         self.assertTrue(model_onnx is not None)
         dump_data_and_model(
             X, pls2, model_onnx, methods=['predict'],
-            basename="SklearnPLSRegression64",
-            allow_failure="StrictVersion("
-            "onnxruntime.__version__)<= StrictVersion('0.2.1')")
+            basename="SklearnPLSRegression64")
 
     @unittest.skipIf(not onnx_built_with_ml(),
                      reason="Requires ONNX-ML extension.")
@@ -78,9 +74,7 @@ class TestSklearnPLSRegressionConverters(unittest.TestCase):
         self.assertTrue(model_onnx is not None)
         dump_data_and_model(
             X, pls2, model_onnx, methods=['predict'],
-            basename="SklearnPLSRegressionInt64",
-            allow_failure="StrictVersion("
-            "onnxruntime.__version__)<= StrictVersion('0.2.1')")
+            basename="SklearnPLSRegressionInt64")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
scikit-learn 1.1 introduces changes which make some unit test fail. This PR makes fixes to that end.

* some unit test were converting unfitted model, this fails with sklearn 1.1
* Attributes PLSRegression were renamed in sklearn 1.1