### PR TITLE
Allow empty array as feature_names_out

### DIFF
--- a/skl2onnx/_parse.py
+++ b/skl2onnx/_parse.py
@@ -230,10 +230,6 @@ def _parse_sklearn_simple_model(scope, model, inputs, custom_parsers=None,
                 # Catch a bug in scikit-learn.
                 out_names = None
             this_operator.feature_names_out_ = out_names
-            if out_names is not None and len(out_names) == 0:
-                raise RuntimeError(
-                    "get_feature_names_out() cannot return an empty value, "
-                    "model is %r." % type(model))
         input_type = guess_tensor_type(inputs[0].type)
         variable = scope.declare_local_variable(
             'variable', input_type)


### PR DESCRIPTION
I don't understand why this should be not allowed.

We use a feature filter step in our pipeline which filters away all features in some cases. This used to work fine with older versions of sklearn before `feature_names_out` and `feature_names_in` were introduced. 

Unfortunately, our converter doesn't work anymore because of this check. Removing it resolves the problem.