### PR TITLE
MAINT compat link function and loss for sklearn 1.1

### DIFF
--- a/skl2onnx/operator_converters/gradient_boosting.py
+++ b/skl2onnx/operator_converters/gradient_boosting.py
@@ -20,7 +20,7 @@ def convert_sklearn_gradient_boosting_classifier(
     if dtype != np.float64:
         dtype = np.float32
     op = operator.raw_operator
-    if op.loss != 'deviance':
+    if op.loss not in ('deviance', 'log_loss'):
         raise NotImplementedError(
             "Loss '{0}' is not supported yet. You "
             "may raise an issue at "

--- a/skl2onnx/operator_converters/linear_regressor.py
+++ b/skl2onnx/operator_converters/linear_regressor.py
@@ -155,17 +155,46 @@ def convert_sklearn_poisson_regressor(scope: Scope, operator: Operator,
         OnnxMatMul(input_var, op.coef_.astype(dtype), op_version=opv),
         intercept, op_version=opv)
 
-    from sklearn.linear_model._glm.link import IdentityLink, LogLink, LogitLink
-    if isinstance(op._link_instance, IdentityLink):
-        Y = OnnxIdentity(eta, op_version=opv)
-    elif isinstance(op._link_instance, LogLink):
-        Y = OnnxExp(eta, op_version=opv)
-    elif isinstance(op._link_instance, LogitLink):
-        Y = OnnxSigmoid(eta, op_version=opv)
+    if hasattr(op, "_link_instance"):
+        # scikit-learn < 1.1
+        from sklearn.linear_model._glm.link import IdentityLink, LogLink, LogitLink
+        if isinstance(op._link_instance, IdentityLink):
+            Y = OnnxIdentity(eta, op_version=opv)
+        elif isinstance(op._link_instance, LogLink):
+            Y = OnnxExp(eta, op_version=opv)
+        elif isinstance(op._link_instance, LogitLink):
+            Y = OnnxSigmoid(eta, op_version=opv)
+        else:
+            raise RuntimeError(
+                "Unexpected type %r for _link_instance in operator type %r."
+                "" % (type(op._link_instance), type(op)))
     else:
-        raise RuntimeError(
-            "Unexpected type %r for _link_instance in operator type %r."
-            "" % (type(op._link_instance), type(op)))
+        # scikit-learn >= 1.1
+        from sklearn._loss.loss import (
+            AbsoluteError,
+            HalfBinomialLoss,
+            HalfGammaLoss,
+            HalfPoissonLoss,
+            HalfSquaredError,
+            HalfTweedieLoss,
+            HalfTweedieLossIdentity,
+            PinballLoss
+        )
+        loss = op._get_loss()
+        if isinstance(
+            loss,
+            (AbsoluteError, HalfSquaredError, HalfTweedieLossIdentity, PinballLoss),
+        ):
+            Y = OnnxIdentity(eta, op_version=opv)
+        elif isinstance(loss, (HalfPoissonLoss, HalfGammaLoss, HalfTweedieLoss)):
+            Y = OnnxExp(eta, op_version=opv)
+        elif isinstance(loss, HalfBinomialLoss):
+            Y = OnnxSigmoid(eta, op_version=opv)
+        else:
+            raise RuntimeError(
+                f"Unexpected type of link for {loss!r} loss in operator type {op!r}."
+            )
+
     last_dim = 1 if len(op.coef_.shape) == 1 else op.coef_.shape[-1]
     final = OnnxReshape(Y, np.array([-1, last_dim], dtype=np.int64),
                         op_version=opv, output_names=out[:1])


### PR DESCRIPTION
We released an RC for scikit-learn 1.1.

I tried to check if we break anything in `sklearn-onnx`.
I could spot a couple of issues linked to some change of a default for the loss in GBDT and we internally refactor the losses and link functions in the GLM.

I am not familiar with the code so the tests might still not pass but it could be a good approximation to show what to do to migrate to scikit-learn 1.1

@xadupre might be interested to have a look.