### PR TITLE
restrict protobuf upgrade to v4.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.15
 scipy>=1.0
-protobuf
+protobuf<4
 onnx>=1.2.1
 scikit-learn>=0.19
 onnxconverter-common>=1.7.0


### PR DESCRIPTION
See
https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
for details.

When using `skl2onnx` with `protobuf>4` an error like the following gets
thrown:

```
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```