### PR TITLE
Deduplicate requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,5 @@ numpy>=1.15
 scipy>=1.0
 protobuf
 onnx>=1.2.1
-scikit-learn>=0.19
-scikit-learn<=1.1.1
+scikit-learn>=0.19, <=1.1.1
 onnxconverter-common>=1.7.0
-scikit-learn<=1.1.1


### PR DESCRIPTION
There are currently 3 occurrences of `scikit-learn` in `requirements.txt`. This creates non-deterministic downstream behavior, for example [piptools](https://github.com/jazzband/pip-tools) compilation would randomly pick a specifier as the source of truth, `pip install skl2onnx` either install `scikit-learn>=0.19` or `scikit-learn<=1.1.1`.

Before `setuptools` has a solution for deduplicating requirements when running `setup`(https://github.com/pypa/setuptools/issues/1467), the best way going forward is to unify `scikit-learn` requirements in skl2onnx.