### PR TITLE
Concat | Shape Calculator 

### DIFF
--- a/skl2onnx/shape_calculators/concat.py
+++ b/skl2onnx/shape_calculators/concat.py
@@ -32,7 +32,7 @@ def calculate_sklearn_concat(operator):
                 C += 1
             else:
                 C = None
-        if len(seen_types) == 0:
+        if i.type not in seen_types:
             seen_types.append(i.type)
 
     def more_generic(t1, t2):
@@ -60,9 +60,9 @@ def calculate_sklearn_concat(operator):
     for seen in seen_types:
         if final_type is None:
             final_type = seen
-        elif seen != final_type:
+        elif seen.to_onnx_type() != final_type.to_onnx_type():
             merged_type = more_generic(final_type, seen)
-            if merged_type:
+            if isinstance(seen, merged_type):
                 final_type = seen
 
     if final_type is None:

--- a/tests/test_sklearn_concat.py
+++ b/tests/test_sklearn_concat.py
@@ -174,7 +174,7 @@ class TestConcatOutputType(unittest.TestCase):
                               target_opset=TARGET_OPSET)
 
         # make sure that the output of the concat is a float
-        # we are concatenating an `int` with a `float`, and 
+        # we are concatenating an `int` with a `float`, and
         # thus the more generic typing is `float`
         out_type = onx.graph.output[0].type.tensor_type.elem_type
         right_type = FloatTensorType().to_onnx_type().tensor_type.elem_type

--- a/tests/test_sklearn_concat.py
+++ b/tests/test_sklearn_concat.py
@@ -12,7 +12,11 @@ try:
 except ImportError:
     ColumnTransformer = None
 from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import StandardScaler, OneHotEncoder, FunctionTransformer
+from sklearn.preprocessing import (
+    StandardScaler,
+    OneHotEncoder,
+    FunctionTransformer
+)
 from skl2onnx import convert_sklearn
 from skl2onnx.common.data_types import (
     BooleanTensorType, FloatTensorType,
@@ -148,7 +152,7 @@ class TestConcatOutputType(unittest.TestCase):
 
         # load to dataframe
         data = pd.DataFrame.from_dict(data_dict)
-        
+
         # create a simple transformer:
         #   - identity function for column `a`
         #   - standard scaler for column `b`
@@ -158,7 +162,7 @@ class TestConcatOutputType(unittest.TestCase):
                 ("b", StandardScaler(), ["b"])
             ],
         )
-        
+
         # fit the transformer
         col_transformer.fit(data)
 
@@ -170,9 +174,12 @@ class TestConcatOutputType(unittest.TestCase):
                               target_opset=TARGET_OPSET)
 
         # make sure that the output of the concat is a float
-        # we are concatenating an `int` with a `float`, and thus the more generic typing is `float`
+        # we are concatenating an `int` with a `float`, and 
+        # thus the more generic typing is `float`
+        out_type = onx.graph.output[0].type.tensor_type.elem_type
+        right_type = FloatTensorType().to_onnx_type().tensor_type.elem_type
         assert (
-            onx.graph.output[0].type.tensor_type.elem_type == FloatTensorType().to_onnx_type().tensor_type.elem_type
+            out_type == right_type
         ), "The `concat` output does not have the expected output type."
 
 


### PR DESCRIPTION
Signed-off-by: fillassuncao <fillassuncao@gmail.com>

This PR addresses some issues in the shape calculator of the concat operator, namely:
 - when computing the `seen_types` we are only adding when the list is empty;
 - the computation of the `final_type` is not correct.