### PR TITLE
Add function add_onnx_graph to insert an onnx graph in a pipeline

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1,8 +1,9 @@
-Change Logs
-===========
+# Change Logs
 
-1.16.0
-++++++
+## 1.16.0
 
+* add function 'add_onnx_graph' to insert onnx graph coming from other converting
+  libraries within the converter mapped to a custom estimator
+  [#1023](https://github.com/onnx/sklearn-onnx/pull/1023)
 * add option 'language' to converters of CountVectorizer, TfIdfVectorizer
   [#1020](https://github.com/onnx/sklearn-onnx/pull/1020)

--- a/docs/api_summary.rst
+++ b/docs/api_summary.rst
@@ -63,6 +63,11 @@ lists all available converters.
 
 .. autofunction:: skl2onnx.update_registered_parser
 
+Helpers for new converters
+==========================
+
+.. autofunction:: skl2onnx.helpers.integration.add_onnx_graph
+
 Manipulate ONNX graphs
 ======================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,6 +110,10 @@ Other converters can be found on `github/onnx <https://github.com/onnx/>`_,
 `ONNX-MXNet API <https://mxnet.incubator.apache.org/api/python/contrib/onnx.html>`_,
 `Microsoft.ML.Onnx <https://www.nuget.org/packages/Microsoft.ML.Onnx/>`_...
 
+**Change Logs**
+
+See `CHANGELOGS.md <https://github.com/onnx/sklearn-onnx/blob/main/CHANGELOGS.md>`_.
+
 **Credits**
 
 The package was started by the following engineers and data scientists at

--- a/skl2onnx/helpers/integration.py
+++ b/skl2onnx/helpers/integration.py
@@ -65,8 +65,7 @@ def add_onnx_graph(
     """
     Adds a whole ONNX graph to an existing one following
     :epkg:`skl2onnx` API assuming this ONNX graph implements
-    an `operator <http://onnx.ai/sklearn-onnx/api_summary.html?
-    highlight=operator#skl2onnx.common._topology.Operator>`_.
+    an `operator <http://onnx.ai/sklearn-onnx/api_summary.htmlskl2onnx.common._topology.Operator>`_.
 
     :param scope: scope (to get unique names)
     :param operator: operator

--- a/skl2onnx/helpers/integration.py
+++ b/skl2onnx/helpers/integration.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Tuple, Union
+from onnx import helper, ModelProto, TensorProto, ValueInfoProto, TypeProto
+
+from ..common._topology import Scope, Operator
+from ..common._container import ModelComponentContainer
+
+
+def get_tensor_shape(obj: Union[ValueInfoProto, TypeProto]) -> Tuple[int, ...]:
+    """
+    Returns the shape if that makes sense for this object.
+    """
+    if isinstance(obj, ValueInfoProto):
+        return get_tensor_shape(obj.type)
+    if not isinstance(obj, TypeProto):
+        raise TypeError(f"Unexpected type {type(obj)!r}.")
+    shape = []
+    for d in obj.tensor_type.shape.dim:
+        v = d.dim_value if d.dim_value > 0 else d.dim_param
+        shape.append(v)
+    if len(shape) == 0:
+        shape = None
+    else:
+        shape = list(None if s == 0 else s for s in shape)
+    return shape
+
+
+def get_tensor_elem_type(obj: Union[ValueInfoProto, TypeProto]) -> int:
+    """
+    Returns the element type if that makes sense for this object.
+    """
+    if isinstance(obj, ValueInfoProto):
+        return get_tensor_elem_type(obj.type)
+    if not isinstance(obj, TypeProto):
+        raise TypeError(f"Unexpected type {type(obj)!r}.")
+    return obj.tensor_type.elem_type
+
+
+def _copy_inout(inout, scope, new_name):
+    shape = get_tensor_shape(inout)
+    elem_type = get_tensor_elem_type(inout)
+    value_info = helper.make_tensor_value_info(new_name, elem_type, shape)
+    return value_info
+
+
+def _clean_variable_name(name, scope):
+    return scope.get_unique_variable_name(name)
+
+
+def _clean_operator_name(name, scope):
+    return scope.get_unique_operator_name(name)
+
+
+def _clean_initializer_name(name, scope):
+    return scope.get_unique_variable_name(name)
+
+
+def add_onnx_graph(
+    scope: Scope,
+    operator: Operator,
+    container: ModelComponentContainer,
+    onx: ModelProto,
+):
+    """
+    Adds a whole ONNX graph to an existing one following
+    :epkg:`skl2onnx` API assuming this ONNX graph implements
+    an `operator <http://onnx.ai/sklearn-onnx/api_summary.html?
+    highlight=operator#skl2onnx.common._topology.Operator>`_.
+
+    :param scope: scope (to get unique names)
+    :param operator: operator
+    :param container: container
+    :param onx: ONNX graph
+    """
+    graph = onx.graph
+    name_mapping = {}
+    node_mapping = {}
+    for node in graph.node:
+        name = node.name
+        if name is not None:
+            node_mapping[node.name] = _clean_initializer_name(node.name, scope)
+        for o in node.input:
+            name_mapping[o] = _clean_variable_name(o, scope)
+        for o in node.output:
+            name_mapping[o] = _clean_variable_name(o, scope)
+    for o in graph.initializer:
+        name_mapping[o.name] = _clean_operator_name(o.name, scope)
+
+    inputs = [_copy_inout(o, scope, name_mapping[o.name]) for o in graph.input]
+    outputs = [_copy_inout(o, scope, name_mapping[o.name]) for o in graph.output]
+
+    for inp, to in zip(operator.inputs, inputs):
+        n = helper.make_node(
+            "Identity",
+            [inp.onnx_name],
+            [to.name],
+            name=_clean_operator_name("Identity", scope),
+        )
+        container.nodes.append(n)
+
+    for inp, to in zip(outputs, operator.outputs):
+        n = helper.make_node(
+            "Identity",
+            [inp.name],
+            [to.onnx_name],
+            name=_clean_operator_name("Identity", scope),
+        )
+        container.nodes.append(n)
+
+    for node in graph.node:
+        n = helper.make_node(
+            node.op_type,
+            [name_mapping[o] for o in node.input],
+            [name_mapping[o] for o in node.output],
+            name=node_mapping[node.name] if node.name else None,
+            domain=node.domain if node.domain else None,
+        )
+        n.attribute.extend(node.attribute)
+        container.nodes.append(n)
+
+    for o in graph.initializer:
+        as_str = o.SerializeToString()
+        tensor = TensorProto()
+        tensor.ParseFromString(as_str)
+        tensor.name = name_mapping[o.name]
+        container.initializers.append(tensor)
+
+    # opset
+    for oimp in onx.opset_import:
+        container.node_domain_version_pair_sets.add((oimp.domain, oimp.version))

--- a/tests/test_other_converter_library_pipelines.py
+++ b/tests/test_other_converter_library_pipelines.py
@@ -68,6 +68,7 @@ def my_custom_converter_add(scope, operator, container):
         operator.raw_operator.estimator_,
         initial_types=operator.inputs,
         options={"zipmap": False},
+        target_opset=TARGET_OPSET,
     )
     add_onnx_graph(scope, operator, container, onx)
 
@@ -147,7 +148,7 @@ class TestOtherLibrariesInPipeline(unittest.TestCase):
             basename="SklearnPipelineScalerCustomClassifier2",
         )
 
-    def test_add_onn_graph(self):
+    def test_add_onnx_graph(self):
         data = load_iris()
         X = data.data[:, :2]
         y = data.target

--- a/tests/test_other_converter_library_pipelines.py
+++ b/tests/test_other_converter_library_pipelines.py
@@ -11,13 +11,14 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.pipeline import Pipeline
 from sklearn.linear_model import LogisticRegression
 from skl2onnx.common.data_types import FloatTensorType
-from skl2onnx import convert_sklearn, update_registered_converter
+from skl2onnx import convert_sklearn, to_onnx, update_registered_converter
 from skl2onnx.common.shape_calculator import (
     calculate_linear_classifier_output_shapes,
 )
 from skl2onnx.operator_converters.linear_classifier import (
     convert_sklearn_linear_classifier,
 )
+from skl2onnx.helpers.integration import add_onnx_graph
 from test_utils import dump_data_and_model, TARGET_OPSET
 
 
@@ -56,6 +57,19 @@ def my_custom_converter(scope, operator, container):
     operator.raw_operator = raw.estimator_
     convert_sklearn_linear_classifier(scope, operator, container)
     operator.raw_operator = raw
+
+
+class MyCustomClassifierAdd(MyCustomClassifier):
+    pass
+
+
+def my_custom_converter_add(scope, operator, container):
+    onx = to_onnx(
+        operator.raw_operator.estimator_,
+        initial_types=operator.inputs,
+        options={"zipmap": False},
+    )
+    add_onnx_graph(scope, operator, container, onx)
 
 
 class TestOtherLibrariesInPipeline(unittest.TestCase):
@@ -131,6 +145,32 @@ class TestOtherLibrariesInPipeline(unittest.TestCase):
             pipe,
             model_onnx,
             basename="SklearnPipelineScalerCustomClassifier2",
+        )
+
+    def test_add_onn_graph(self):
+        data = load_iris()
+        X = data.data[:, :2]
+        y = data.target
+
+        model = MyCustomClassifierAdd()
+        pipe = Pipeline([("scaler", StandardScaler()), ("lgbm", model)])
+        pipe.fit(X, y)
+
+        model_onnx = convert_sklearn(
+            pipe,
+            "pipeline",
+            [("input", FloatTensorType([None, 2]))],
+            custom_conversion_functions={
+                MyCustomClassifierAdd: my_custom_converter_add
+            },
+            custom_shape_calculators={MyCustomClassifierAdd: my_custom_shape_extractor},
+            target_opset=TARGET_OPSET,
+        )
+        dump_data_and_model(
+            X.astype(numpy.float32),
+            pipe,
+            model_onnx,
+            basename="SklearnPipelineScalerCustomClassifierAdd",
         )
 
 


### PR DESCRIPTION
Function add_onnx_graph makes it easier to write custom converters for model coming from other framework. See issue #1014 for an example.