### PR TITLE
OrdinalEncoder conversion fixes

### DIFF
--- a/skl2onnx/operator_converters/ordinal_encoder.py
+++ b/skl2onnx/operator_converters/ordinal_encoder.py
@@ -11,96 +11,81 @@ from ..proto import onnx_proto
 
 
 def convert_sklearn_ordinal_encoder(
-    scope: Scope, operator: Operator, container: ModelComponentContainer
+        scope: Scope, operator: Operator, container: ModelComponentContainer
 ):
     ordinal_op = operator.raw_operator
     result = []
-    concatenated_input_name = operator.inputs[0].full_name
-    concat_result_name = scope.get_unique_variable_name("concat_result")
+    input_idx = 0
+    dimension_idx = 0
+    for categories in ordinal_op.categories_:
+        if len(categories) == 0:
+            continue
 
-    if len(operator.inputs) > 1:
-        concatenated_input_name = scope.get_unique_variable_name("concatenated_input")
-        if all(
-            isinstance(inp.type, type(operator.inputs[0].type))
-            for inp in operator.inputs
-        ):
-            input_names = list(map(lambda x: x.full_name, operator.inputs))
+        current_input = operator.inputs[input_idx]
+        if current_input.get_second_dimension() == 1:
+            feature_column_name = current_input.onnx_name
+            input_idx += 1
         else:
-            input_names = []
-            for inp in operator.inputs:
-                if isinstance(inp.type, Int64TensorType):
-                    input_names.append(scope.get_unique_variable_name("cast_input"))
-                    apply_cast(
-                        scope,
-                        inp.full_name,
-                        input_names[-1],
-                        container,
-                        to=onnx_proto.TensorProto.STRING,
-                    )
-                elif isinstance(inp.type, StringTensorType):
-                    input_names.append(inp.full_name)
-                else:
-                    raise NotImplementedError(
-                        "{} input datatype not yet supported. "
-                        "You may raise an issue at "
-                        "https://github.com/onnx/sklearn-onnx/issues"
-                        "".format(type(inp.type))
-                    )
-
-        apply_concat(scope, input_names, concatenated_input_name, container, axis=1)
-    if len(ordinal_op.categories_) == 0:
-        raise RuntimeError(
-            "No categories found in type=%r, encoder=%r."
-            % (type(ordinal_op), ordinal_op)
-        )
-    for index, categories in enumerate(ordinal_op.categories_):
-        attrs = {"name": scope.get_unique_operator_name("LabelEncoder")}
-        if len(categories) > 0:
-            if (
-                np.issubdtype(categories.dtype, np.floating)
-                or categories.dtype == np.bool_
-            ):
-                attrs["keys_floats"] = categories
-            elif np.issubdtype(categories.dtype, np.signedinteger):
-                attrs["keys_int64s"] = categories
-            else:
-                attrs["keys_strings"] = np.array(
-                    [str(s).encode("utf-8") for s in categories]
-                )
-            attrs["values_int64s"] = np.arange(len(categories)).astype(np.int64)
-
             index_name = scope.get_unique_variable_name("index")
-            feature_column_name = scope.get_unique_variable_name("feature_column")
-            result.append(scope.get_unique_variable_name("ordinal_output"))
-            label_encoder_output = scope.get_unique_variable_name("label_encoder")
-
             container.add_initializer(
-                index_name, onnx_proto.TensorProto.INT64, [], [index]
+                index_name, onnx_proto.TensorProto.INT64, [], [dimension_idx]
             )
+
+            feature_column_name = scope.get_unique_variable_name(
+                "feature_column")
 
             container.add_node(
                 "ArrayFeatureExtractor",
-                [concatenated_input_name, index_name],
+                [current_input.onnx_name, index_name],
                 feature_column_name,
                 op_domain="ai.onnx.ml",
                 name=scope.get_unique_operator_name("ArrayFeatureExtractor"),
             )
 
-            container.add_node(
-                "LabelEncoder",
-                feature_column_name,
-                label_encoder_output,
-                op_domain="ai.onnx.ml",
-                op_version=2,
-                **attrs
+            dimension_idx += 1
+            if dimension_idx == current_input.get_second_dimension():
+                dimension_idx = 0
+                input_idx += 1
+
+        attrs = {"name": scope.get_unique_operator_name("LabelEncoder")}
+        if (
+                np.issubdtype(categories.dtype, np.floating)
+                or categories.dtype == np.bool_
+                or isinstance(categories[0], float)
+        ):
+            attrs["keys_floats"] = categories
+        elif (
+                np.issubdtype(categories.dtype, np.signedinteger)
+                or isinstance(categories[0], int)
+        ):
+            attrs["keys_int64s"] = categories
+        else:
+            attrs["keys_strings"] = np.array(
+                [str(s).encode("utf-8") for s in categories]
             )
-            apply_reshape(
-                scope,
-                label_encoder_output,
-                result[-1],
-                container,
-                desired_shape=(-1, 1),
-            )
+        attrs["values_int64s"] = np.arange(len(categories)).astype(np.int64)
+
+        result.append(scope.get_unique_variable_name("ordinal_output"))
+        label_encoder_output = scope.get_unique_variable_name(
+            "label_encoder")
+
+        container.add_node(
+            "LabelEncoder",
+            feature_column_name,
+            label_encoder_output,
+            op_domain="ai.onnx.ml",
+            op_version=2,
+            **attrs
+        )
+        apply_reshape(
+            scope,
+            label_encoder_output,
+            result[-1],
+            container,
+            desired_shape=(-1, 1),
+        )
+
+    concat_result_name = scope.get_unique_variable_name("concat_result")
     apply_concat(scope, result, concat_result_name, container, axis=1)
     cast_type = (
         onnx_proto.TensorProto.FLOAT
@@ -108,7 +93,8 @@ def convert_sklearn_ordinal_encoder(
         else onnx_proto.TensorProto.INT64
     )
     apply_cast(
-        scope, concat_result_name, operator.output_full_names, container, to=cast_type
+        scope, concat_result_name, operator.output_full_names, container,
+        to=cast_type
     )
 
 

--- a/tests/test_sklearn_ordinal_encoder.py
+++ b/tests/test_sklearn_ordinal_encoder.py
@@ -4,6 +4,7 @@
 import unittest
 import packaging.version as pv
 import numpy as np
+import pandas as pd
 import onnxruntime
 from sklearn import __version__ as sklearn_version
 
@@ -76,6 +77,40 @@ class TestSklearnOrdinalEncoderConverter(unittest.TestCase):
         self.assertTrue(model_onnx is not None)
         dump_data_and_model(
             test, model, model_onnx, basename="SklearnOrdinalEncoderMixedStringIntDrop"
+        )
+
+    @unittest.skipIf(
+        not ordinal_encoder_support(),
+        reason="OrdinalEncoder was not available before 0.20",
+    )
+    @unittest.skipIf(TARGET_OPSET < 9, reason="not available")
+    def test_ordinal_encoder_mixed_string_int_pandas(self):
+        col1 = 'col1'
+        col2 = 'col2'
+        col3 = 'col3'
+        data_pd = pd.DataFrame({
+            col1: np.array(["c0.4", "c1.4", "c0.2", "c0.2", "c0.2", "c0.2"]),
+            col2: np.array(["c0.2", "c1.2", "c2.2", "c2.2", "c2.2", "c2.2"]),
+            col3: np.array([3, 0, 1, 1, 1, 1]),
+        })
+        test_pd = pd.DataFrame({
+            col1: np.array(["c0.2"]),
+            col2: np.array(["c2.2"]),
+            col3: np.array([1]),
+
+        })
+        model = OrdinalEncoder(categories="auto")
+        model.fit(data_pd)
+        inputs = [
+            ("input1", StringTensorType([None, 2])),
+            ("input2", Int64TensorType([None, 1])),
+        ]
+        model_onnx = convert_sklearn(
+            model, "ordinal encoder", inputs, target_opset=TARGET_OPSET
+        )
+        self.assertTrue(model_onnx is not None)
+        dump_data_and_model(
+            test_pd, model, model_onnx, basename="SklearnOrdinalEncoderMixedStringIntPandas"
         )
 
     @unittest.skipIf(


### PR DESCRIPTION
Hello! Thank you for this awesome library that helps me to use sklearn models in highly loaded systems.

I think I found some problems for OrdinalEncoder conversion. Current implementation doesn't work with encoder that was fitted on data with different column datatypes. For example, if I pass to fit() function pandas dataframe with different column datatypes (np.int64, object), I get error when I try run ONNX model using onnxruntime framework because ONNX model contains inconsistent attributes for LabelEncoder operator.

My suggestion is removing cast to string for each input variable and pay attention not only to the `categories_` array dtype but also to the type of `categories_` values because in your `test_ordinal_encoder_mixed_string_int_drop()` function `categories_` array is object dtype, but values type is int.

In the end I want attach demo jupyter notebook and ONNX models with old and new conversions for problem demonstration.
[ordinal_encoder.zip](https://github.com/onnx/sklearn-onnx/files/13325554/ordinal_encoder.zip)

I will be waiting for comments on my pull request