### PR TITLE
Increase last supported opset to 19 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ including models or transformers coming from external libraries.
 ## Documentation
 Full documentation including tutorials is available at [https://onnx.ai/sklearn-onnx/](https://onnx.ai/sklearn-onnx/).
 [Supported scikit-learn Models](https://onnx.ai/sklearn-onnx/supported.html)
-Last supported opset is 15.
+Last supported opset is 19.
 
 You may also find answers in [existing issues](https://github.com/onnx/sklearn-onnx/issues?utf8=%E2%9C%93&q=is%3Aissue)
 or submit a new one.


### PR DESCRIPTION
See: https://github.com/onnx/sklearn-onnx/blob/d2029c1a9752f62a63fc5c4447b4d9fe75e8fe39/skl2onnx/__init__.py#L12

I was confused why I could not convert the model to with opset 20, but with 19, even though the doc said only up to 15 is supported. I think the doc is simply out of date.