### PR TITLE
Support fill_value for SimpleImputer with string data

### DIFF
--- a/skl2onnx/operator_converters/imputer_op.py
+++ b/skl2onnx/operator_converters/imputer_op.py
@@ -17,14 +17,6 @@ def convert_sklearn_imputer(
     op_type = "Imputer"
     attrs = {"name": scope.get_unique_operator_name(op_type)}
     op = operator.raw_operator
-    if (
-        hasattr(op, "fill_value")
-        and isinstance(op.fill_value, str)
-        and op.fill_value.lower() != "nan"
-    ):
-        raise RuntimeError(
-            "Imputer cannot fill missing values with a string '%s'." % op.fill_value
-        )
     if not hasattr(op, "statistics_"):
         raise RuntimeError("Member statistics_ is not present, was the model fitted?")
 
@@ -86,6 +78,14 @@ def convert_sklearn_imputer(
 
         apply_concat(scope, names, operator.outputs[0].full_name, container, axis=1)
     else:
+        if (
+            hasattr(op, "fill_value")
+            and isinstance(op.fill_value, str)
+            and op.fill_value.lower() != "nan"
+        ):
+            raise RuntimeError(
+                "Imputer cannot fill missing values with a string '%s'." % op.fill_value
+            )
         if isinstance(operator.inputs[0].type, Int64TensorType):
             attrs["imputed_value_int64s"] = op.statistics_.astype(np.int64)
             use_int = True


### PR DESCRIPTION
Adds support for setting the `fill_value` of a SimpleImputer using the constant strategy on string data. This is done by moving the existing guard statement that limits string values of `fill_value` to be only the value "nan".

Based on some testing, likely this guard statement can be removed completely due to sci-kit learn doing it's own casting checks when fitting data to the SimpleImputer (see <https://github.com/scikit-learn/scikit-learn/blob/5600faab452b0adb1f4090219012aa3ae6208c66/sklearn/impute/_base.py#L375-L398>). I moved the statement in this PR, in case there was some edge case I missed while doing my own checks and there is some numeric SimpleImputer that allows `fill_value=="nan"`. But let me know if you rather I remove it outright.

Addresses #1122 


