### PR TITLE
TargetEncoder support

### DIFF
--- a/skl2onnx/_supported_operators.py
+++ b/skl2onnx/_supported_operators.py
@@ -244,6 +244,7 @@ from sklearn.preprocessing import (
     LabelEncoder,
     Normalizer,
     OneHotEncoder,
+    TargetEncoder,
 )
 
 try:
@@ -464,6 +465,7 @@ def build_sklearn_operator_name_map():
             StackingRegressor,
             SVC,
             SVR,
+            TargetEncoder,
             TfidfVectorizer,
             TfidfTransformer,
             TruncatedSVD,
@@ -512,6 +514,7 @@ def build_sklearn_operator_name_map():
             SGDRegressor: "SklearnLinearRegressor",
             StandardScaler: "SklearnScaler",
             TheilSenRegressor: "SklearnLinearRegressor",
+            TargetEncoder: "SklearnTargetEncoder",
         }
     )
     if None in res:
@@ -569,8 +572,9 @@ def update_registered_converter(
         and alias != sklearn_operator_name_map[model]
     ):
         warnings.warn(
-            "Model '{0}' was already registered under alias "
-            "'{1}'.".format(model, sklearn_operator_name_map[model]),
+            "Model '{0}' was already registered under alias " "'{1}'.".format(
+                model, sklearn_operator_name_map[model]
+            ),
             stacklevel=0,
         )
     sklearn_operator_name_map[model] = alias
@@ -580,9 +584,7 @@ def update_registered_converter(
         from ._parse import update_registered_parser
 
         update_registered_parser(model, parser)
-    elif options is not None and (
-        "zipmap" in options or "output_class_labels" in options
-    ):
+    elif options is not None and ("zipmap" in options or "output_class_labels" in options):
         from ._parse import _parse_sklearn_classifier, update_registered_parser
 
         update_registered_parser(model, _parse_sklearn_classifier)

--- a/skl2onnx/_supported_operators.py
+++ b/skl2onnx/_supported_operators.py
@@ -465,7 +465,6 @@ def build_sklearn_operator_name_map():
             StackingRegressor,
             SVC,
             SVR,
-            TargetEncoder,
             TfidfVectorizer,
             TfidfTransformer,
             TruncatedSVD,
@@ -513,8 +512,8 @@ def build_sklearn_operator_name_map():
             RidgeClassifierCV: "SklearnLinearClassifier",
             SGDRegressor: "SklearnLinearRegressor",
             StandardScaler: "SklearnScaler",
-            TheilSenRegressor: "SklearnLinearRegressor",
             TargetEncoder: "SklearnTargetEncoder",
+            TheilSenRegressor: "SklearnLinearRegressor",
         }
     )
     if None in res:
@@ -572,9 +571,8 @@ def update_registered_converter(
         and alias != sklearn_operator_name_map[model]
     ):
         warnings.warn(
-            "Model '{0}' was already registered under alias " "'{1}'.".format(
-                model, sklearn_operator_name_map[model]
-            ),
+            "Model '{0}' was already registered under alias "
+            "'{1}'.".format(model, sklearn_operator_name_map[model]),
             stacklevel=0,
         )
     sklearn_operator_name_map[model] = alias
@@ -584,7 +582,9 @@ def update_registered_converter(
         from ._parse import update_registered_parser
 
         update_registered_parser(model, parser)
-    elif options is not None and ("zipmap" in options or "output_class_labels" in options):
+    elif options is not None and (
+        "zipmap" in options or "output_class_labels" in options
+    ):
         from ._parse import _parse_sklearn_classifier, update_registered_parser
 
         update_registered_parser(model, _parse_sklearn_classifier)

--- a/skl2onnx/operator_converters/__init__.py
+++ b/skl2onnx/operator_converters/__init__.py
@@ -61,6 +61,7 @@ from . import sgd_classifier
 from . import sgd_oneclass_svm
 from . import stacking
 from . import support_vector_machines
+from . import target_encoder
 from . import text_vectoriser
 from . import tfidf_transformer
 from . import tfidf_vectoriser
@@ -128,6 +129,7 @@ __all__ = [
     sgd_oneclass_svm,
     stacking,
     support_vector_machines,
+    target_encoder,
     text_vectoriser,
     tfidf_transformer,
     tfidf_vectoriser,

--- a/skl2onnx/operator_converters/target_encoder.py
+++ b/skl2onnx/operator_converters/target_encoder.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+import numpy as np
+
+from ..common._apply_operation import apply_cast, apply_concat, apply_reshape
+from ..common._container import ModelComponentContainer
+from ..common.data_types import (
+    FloatTensorType,
+    Int64TensorType,
+)
+from ..common._registration import register_converter
+from ..common._topology import Scope, Operator
+from ..proto import onnx_proto
+
+
+def convert_sklearn_target_encoder(
+    scope: Scope, operator: Operator, container: ModelComponentContainer
+):
+    op = operator.raw_operator
+    result = []
+    input_idx = 0
+    dimension_idx = 0
+
+    # NotImplementedError(   # TODO: assert that we have binary output
+    if (op.target_type_ == "multiclass") or (
+        isinstance(op.classes_.dtype, np.int64) and (len(op.classes_) > 2)
+    ):
+        raise NotImplementedError("multiclass TargetEncoder is not supported")
+    for categories, encodings in zip(op.categories_, op.encodings_):
+        if len(categories) == 0:
+            continue
+
+        current_input = operator.inputs[input_idx]
+        if current_input.get_second_dimension() == 1:
+            feature_column = current_input
+            input_idx += 1
+        else:
+            index_name = scope.get_unique_variable_name("index")
+            container.add_initializer(
+                index_name, onnx_proto.TensorProto.INT64, [], [dimension_idx]
+            )
+
+            feature_column = scope.declare_local_variable(
+                "feature_column",
+                current_input.type.__class__([current_input.get_first_dimension(), 1]),
+            )
+
+            container.add_node(
+                "ArrayFeatureExtractor",
+                [current_input.onnx_name, index_name],
+                feature_column.onnx_name,
+                op_domain="ai.onnx.ml",
+                name=scope.get_unique_operator_name("ArrayFeatureExtractor"),
+            )
+
+            dimension_idx += 1
+            if dimension_idx == current_input.get_second_dimension():
+                dimension_idx = 0
+                input_idx += 1
+
+        attrs = {"name": scope.get_unique_operator_name("LabelEncoder")}
+        if isinstance(feature_column.type, FloatTensorType):
+            attrs["keys_floats"] = np.array([float(s) for s in categories], dtype=np.float32)
+        elif isinstance(feature_column.type, Int64TensorType):
+            attrs["keys_int64s"] = np.array([int(s) for s in categories], dtype=np.int64)
+        else:
+            attrs["keys_strings"] = np.array([str(s).encode("utf-8") for s in categories])
+        attrs["values_floats"] = encodings
+        attrs["default_float"] = op.target_mean_
+
+        result.append(scope.get_unique_variable_name("ordinal_output"))
+        label_encoder_output = scope.get_unique_variable_name("label_encoder")
+
+        container.add_node(
+            "LabelEncoder",
+            feature_column.onnx_name,
+            label_encoder_output,
+            op_domain="ai.onnx.ml",
+            op_version=2,
+            **attrs,
+        )
+        apply_reshape(
+            scope,
+            label_encoder_output,
+            result[-1],
+            container,
+            desired_shape=(-1, 1),
+        )
+
+    concat_result_name = scope.get_unique_variable_name("concat_result")
+    apply_concat(scope, result, concat_result_name, container, axis=1)
+    apply_cast(
+        scope,
+        concat_result_name,
+        operator.output_full_names,
+        container,
+        to=onnx_proto.TensorProto.FLOAT,
+    )
+
+
+register_converter("SklearnTargetEncoder", convert_sklearn_target_encoder)

--- a/skl2onnx/shape_calculators/__init__.py
+++ b/skl2onnx/shape_calculators/__init__.py
@@ -47,6 +47,7 @@ from . import sequence
 from . import sgd_oneclass_svm
 from . import svd
 from . import support_vector_machines
+from . import target_encoder
 from . import text_vectorizer
 from . import tuned_threshold_classifier
 from . import tfidf_transformer
@@ -99,6 +100,7 @@ __all__ = [
     sgd_oneclass_svm,
     svd,
     support_vector_machines,
+    target_encoder,
     text_vectorizer,
     tfidf_transformer,
     tuned_threshold_classifier,

--- a/skl2onnx/shape_calculators/target_encoder.py
+++ b/skl2onnx/shape_calculators/target_encoder.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+
+
+import copy
+from ..common._registration import register_shape_calculator
+from ..common.data_types import FloatTensorType
+from ..common.data_types import Int64TensorType, StringTensorType
+from ..common.utils import check_input_and_output_numbers
+from ..common.utils import check_input_and_output_types
+
+
+def calculate_sklearn_target_encoder_output_shapes(operator):
+    """
+    This function just copy the input shape to the output because target
+    encoder only alters input features' values, not their shape.
+    """
+    check_input_and_output_numbers(operator, output_count_range=1)
+    check_input_and_output_types(
+        operator, good_input_types=[FloatTensorType, Int64TensorType, StringTensorType]
+    )
+
+    N = operator.inputs[0].get_first_dimension()
+    shape = [N, len(operator.raw_operator.categories_)]
+
+    operator.outputs[0].type = FloatTensorType(shape=shape)
+
+
+register_shape_calculator(
+    "SklearnTargetEncoder", calculate_sklearn_target_encoder_output_shapes
+)

--- a/tests/test_sklearn_label_encoder_converter.py
+++ b/tests/test_sklearn_label_encoder_converter.py
@@ -58,7 +58,9 @@ class TestSklearnLabelEncoderConverter(unittest.TestCase):
         self.assertTrue(model_onnx.graph.node is not None)
         if model_onnx.ir_version >= 7 and TARGET_OPSET < 12:
             raise AssertionError("Incompatbilities")
-        dump_data_and_model(data, model, model_onnx, basename="SklearnLabelEncoderFloat")
+        dump_data_and_model(
+            data, model, model_onnx, basename="SklearnLabelEncoderFloat"
+        )
 
     @unittest.skipIf(
         pv.Version(ort_version) < pv.Version("0.3.0"), reason="onnxruntime too old"

--- a/tests/test_sklearn_label_encoder_converter.py
+++ b/tests/test_sklearn_label_encoder_converter.py
@@ -58,9 +58,7 @@ class TestSklearnLabelEncoderConverter(unittest.TestCase):
         self.assertTrue(model_onnx.graph.node is not None)
         if model_onnx.ir_version >= 7 and TARGET_OPSET < 12:
             raise AssertionError("Incompatbilities")
-        dump_data_and_model(
-            data, model, model_onnx, basename="SklearnLabelEncoderFloat"
-        )
+        dump_data_and_model(data, model, model_onnx, basename="SklearnLabelEncoderFloat")
 
     @unittest.skipIf(
         pv.Version(ort_version) < pv.Version("0.3.0"), reason="onnxruntime too old"

--- a/tests/test_sklearn_target_encoder_converter.py
+++ b/tests/test_sklearn_target_encoder_converter.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests scikit-learn's TargetEncoder converter."""
+
+from skl2onnx import convert_sklearn, to_onnx
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.pipeline import make_pipeline
+from sklearn.compose import ColumnTransformer
+from sklearn import __version__ as sklearn_version
+import onnxruntime
+import pandas as pd
+from numpy.testing import assert_almost_equal
+import unittest
+import packaging.version as pv
+import numpy as np
+from onnxruntime import __version__ as ort_version
+from skl2onnx.common.data_types import (
+    Int64TensorType,
+    StringTensorType,
+)
+from test_utils import dump_data_and_model, TARGET_OPSET
+
+try:
+    from sklearn.preprocessing import TargetEncoder
+except ImportError:
+    pass
+
+
+ort_version = ".".join(ort_version.split(".")[:2])
+
+
+def target_encoder_support():
+    # pv.Version does not work with development versions
+    vers = ".".join(sklearn_version.split(".")[:2])
+    if pv.Version(vers) < pv.Version("1.5.0"):
+        return False
+    if pv.Version(onnxruntime.__version__) < pv.Version("0.3.0"):
+        return False
+    return pv.Version(vers) >= pv.Version("1.5.0")
+
+
+def set_output_support():
+    vers = ".".join(sklearn_version.split(".")[:2])
+    return pv.Version(vers) >= pv.Version("1.2")
+
+
+class TestSklearnTargetEncoderConverter(unittest.TestCase):
+    @unittest.skipIf(
+        not target_encoder_support(),
+        reason="TargetEncoder was not available before 1.5",
+    )
+    def test_model_target_encoder(self):
+        model = TargetEncoder()
+        X = np.array(["str3", "str2", "str0", "str1", "str3"]).reshape(-1, 1)
+        y = np.array([0.0, 1.0, 1.0, 0.0, 1.0])
+        model.fit(X, y)
+        model_onnx = convert_sklearn(
+            model,
+            "scikit-learn target encoder",
+            [("input", StringTensorType([None, X.shape[1]]))],
+            target_opset=TARGET_OPSET,
+        )
+        self.assertTrue(model_onnx is not None)
+        self.assertTrue(model_onnx.graph.node is not None)
+        if model_onnx.ir_version >= 7 and TARGET_OPSET < 12:
+            raise AssertionError("Incompatbilities")
+        dump_data_and_model(X, model, model_onnx,
+                            basename="SklearnTargetEncoder")
+
+    @unittest.skipIf(
+        not target_encoder_support(),
+        reason="TargetEncoder was not available before 1.5",
+    )
+    def test_model_target_encoder_int(self):
+        model = TargetEncoder()
+        X = np.array([0, 0, 1, 0, 0, 1, 1], dtype=np.int64).reshape(-1, 1)
+        y = np.array([1, 1, 1, 0, 0, 0, 0], dtype=np.int64)
+        X_test = np.array([0, 1, 2, 1, 0], dtype=np.int64).reshape(-1, 1)
+
+        model.fit(X, y)
+        model_onnx = convert_sklearn(
+            model,
+            "scikit-learn label encoder",
+            [("input", Int64TensorType([None, X.shape[1]]))],
+            target_opset=TARGET_OPSET,
+        )
+        self.assertTrue(model_onnx is not None)
+        self.assertTrue(model_onnx.graph.node is not None)
+        if model_onnx.ir_version >= 7 and TARGET_OPSET < 12:
+            raise AssertionError("Incompatbilities")
+        dump_data_and_model(X_test, model, model_onnx,
+                            basename="SklearnTargetEncoderInt")
+
+    @unittest.skipIf(
+        not target_encoder_support(),
+        reason="TargetEncoder was not available before 1.5",
+    )
+    def test_target_encoder_twocats(self):
+        data = [["cat2"], ["cat1"]]
+        label = [0, 1]
+        model = TargetEncoder(categories="auto")
+        model.fit(data, label)
+        inputs = [("input1", StringTensorType([None, 1]))]
+        model_onnx = convert_sklearn(
+            model, "ordinal encoder two string cats", inputs, target_opset=TARGET_OPSET
+        )
+        self.assertTrue(model_onnx is not None)
+        dump_data_and_model(
+            data, model, model_onnx, basename="SklearnTargetEncoderTwoStringCat"
+        )
+
+    @unittest.skipIf(
+        not set_output_support(),
+        reason="'ColumnTransformer' object has no attribute 'set_output'",
+    )
+    @unittest.skipIf(
+        not target_encoder_support(),
+        reason="TargetEncoder was not available before 1.5",
+    )
+    def test_target_encoder_pipeline_int64(self):
+        from onnxruntime import InferenceSession
+
+        data = pd.DataFrame(
+            {"cat": ["cat2", "cat1"] * 10, "num": [0, 1, 1, 0] * 5})
+        data["num"] = data["num"].astype(np.float32)
+        y = np.array([0, 1, 0, 1] * 5, dtype=np.float32)
+        # target encoder uses cross-fitting and have cv=5 as default, which
+        # caused some folds to have constant y.
+        preprocessor = ColumnTransformer(
+            transformers=[
+                ("cat", TargetEncoder(cv=2), ["cat"]),
+                ("num", "passthrough", ["num"]),
+            ],
+            sparse_threshold=1,
+            verbose_feature_names_out=False,
+        ).set_output(transform="pandas")
+        model = make_pipeline(
+            preprocessor, RandomForestRegressor(n_estimators=3, max_depth=2)
+        )
+        model.fit(data, y)
+        expected = model.predict(data)
+        model_onnx = to_onnx(model, data, target_opset=TARGET_OPSET)
+        sess = InferenceSession(
+            model_onnx.SerializeToString(), providers=["CPUExecutionProvider"]
+        )
+        got = sess.run(
+            None,
+            {
+                "cat": data["cat"].values.reshape((-1, 1)),
+                "num": data["num"].values.reshape((-1, 1)),
+            },
+        )
+        assert_almost_equal(expected, got[0].ravel())
+
+    @unittest.skipIf(
+        not set_output_support(),
+        reason="'ColumnTransformer' object has no attribute 'set_output'",
+    )
+    @unittest.skipIf(
+        not target_encoder_support(),
+        reason="TargetEncoder was not available before 1.5",
+    )
+    def test_target_encoder_pipeline_string_int64(self):
+        from onnxruntime import InferenceSession
+
+        data = pd.DataFrame(
+            {
+                "C1": ["cat2", "cat1", "cat3"] * 10,
+                "C2": [1, 0, 1] * 10,
+                "num": [0, 1, 1] * 10,
+            }
+        )
+        data["num"] = data["num"].astype(np.float32)
+        data["C2"] = data["C2"].astype(np.int64)
+        y = np.array([0, 1, 0, 1, 0, 1] * 5, dtype=np.float32)
+        preprocessor = ColumnTransformer(
+            transformers=[
+                ("cat", TargetEncoder(cv=2), ["C1", "C2"]),
+                ("num", "passthrough", ["num"]),
+            ],
+            sparse_threshold=1,
+            verbose_feature_names_out=False,
+        ).set_output(transform="pandas")
+        model = make_pipeline(
+            preprocessor, RandomForestRegressor(n_estimators=3, max_depth=2)
+        )
+        model.fit(data, y)
+        expected = model.predict(data)
+        model_onnx = to_onnx(model, data, target_opset=TARGET_OPSET)
+        sess = InferenceSession(
+            model_onnx.SerializeToString(), providers=["CPUExecutionProvider"]
+        )
+        got = sess.run(
+            None,
+            {
+                "C1": data["C1"].values.reshape((-1, 1)),
+                "C2": data["C2"].values.reshape((-1, 1)),
+                "num": data["num"].values.reshape((-1, 1)),
+            },
+        )
+        assert_almost_equal(expected, got[0].ravel())
+
+    @unittest.skipIf(
+        not target_encoder_support(),
+        reason="TargetEncoder was not available before 1.5",
+    )
+    @unittest.skipIf(TARGET_OPSET < 9, reason="not available")
+    def test_target_encoder_mixed_string_int_pandas(self):
+        col1 = "col1"
+        col2 = "col2"
+        col3 = "col3"
+        data_pd = pd.DataFrame(
+            {
+                col1: np.array(["c0.4", "c1.4", "c0.2", "c0.2", "c0.2", "c0.2"]),
+                col2: np.array(["c0.2", "c1.2", "c2.2", "c2.2", "c2.2", "c2.2"]),
+                col3: np.array([3, 0, 1, 1, 1, 1]),
+            }
+        )
+        data_label = np.array([0, 0, 1, 1, 1, 0])
+        test_pd = pd.DataFrame(
+            {
+                col1: np.array(["c0.2"]),
+                col2: np.array(["c2.2"]),
+                col3: np.array([1]),
+            }
+        )
+        model = TargetEncoder()
+        model.fit(data_pd, data_label)
+        inputs = [
+            ("input1", StringTensorType([None, 2])),
+            ("input2", Int64TensorType([None, 1])),
+        ]
+        model_onnx = convert_sklearn(
+            model, "ordinal encoder", inputs, target_opset=TARGET_OPSET
+        )
+        self.assertIsNotNone(model_onnx)
+        dump_data_and_model(
+            test_pd,
+            model,
+            model_onnx,
+            basename="SklearnTargetEncoderMixedStringIntPandas",
+        )
+
+    @unittest.skipIf(
+        not target_encoder_support(),
+        reason="TargetEncoder was not available before 1.5",
+    )
+    @unittest.skipIf(TARGET_OPSET < 9, reason="not available")
+    def test_target_encoder_multiclass_assertion(self):
+        model = TargetEncoder()
+        X = np.array([0, 0, 1, 0, 0, 1, 1], dtype=np.int64).reshape(-1, 1)
+        y = np.array([0, 1, 2, 0, 1, 2, 0], dtype=np.int64)
+
+        model.fit(X, y)
+        with self.assertRaises(NotImplementedError):
+            model_onnx = convert_sklearn(
+                model,
+                "scikit-learn label encoder",
+                [("input", Int64TensorType([None, X.shape[1]]))],
+                target_opset=TARGET_OPSET,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_utils/reference_implementation_ml.py
+++ b/tests/test_utils/reference_implementation_ml.py
@@ -51,7 +51,10 @@ if 19 >= onnx_opset_version() >= 18:
                 _meth = FusedMatMul._fmatmul11 if transB else FusedMatMul._fmatmul10
             else:
                 _meth = FusedMatMul._fmatmul01 if transB else FusedMatMul._fmatmul00
-            _meth = lambda a, b: _meth(a, b, alpha)
+
+            def _meth(a, b):
+                return _meth(a, b, alpha)
+
             # more recent versions of the operator
             if transBatchA is None:
                 transBatchA = 0
@@ -234,9 +237,7 @@ if 19 >= onnx_opset_version() >= 18:
                         if j >= 0:
                             res[a, i, j] = 1.0
             else:
-                raise RuntimeError(
-                    f"This operator is not implemented for shape {x.shape}."
-                )
+                raise RuntimeError(f"This operator is not implemented for shape {x.shape}.")
 
             if not self.zeros:
                 red = res.sum(axis=len(res.shape) - 1)
@@ -287,9 +288,8 @@ if 19 >= onnx_opset_version() >= 18:
             if len(set(dimensions)) == 1:
                 res = np.concatenate(args, axis=inputdimensions[0])
                 return (res,)
-            raise RuntimeError(
-                f"inputdimensions={inputdimensions} is not supported yet."
-            )
+            raise RuntimeError(f"inputdimensions={
+                               inputdimensions} is not supported yet.")
 
     class Imputer(OpRun):
         op_domain = "ai.onnx.ml"
@@ -390,8 +390,7 @@ if 19 >= onnx_opset_version() >= 18:
                         dict_labels[v] = i
                 if len(dict_labels) == 0:
                     raise RuntimeError(
-                        "int64_vocabulary and string_vocabulary "
-                        "cannot be both empty."
+                        "int64_vocabulary and string_vocabulary " "cannot be both empty."
                     )
 
                 values = []
@@ -418,4 +417,50 @@ if 19 >= onnx_opset_version() >= 18:
                     res.append(x.get(k, 0))
                 return (np.array(res),)
 
-            raise TypeError(f"x must be iterable not {type(x)}.")  # pragma: no cover
+            raise TypeError(f"x must be iterable not {
+                            type(x)}.")  # pragma: no cover
+
+    class TargetEncoder(OpRun):
+        op_domain = "ai.onnx.ml"
+
+        def _run(
+            self,
+            x,
+            default_float=None,
+            default_int64=None,
+            default_string=None,
+            keys_floats=None,
+            keys_int64s=None,
+            keys_strings=None,
+            values_floats=None,
+            values_int64s=None,
+            values_strings=None,
+        ):
+            keys = keys_floats or keys_int64s or keys_strings
+            values = values_floats or values_int64s or values_strings
+            classes = {k: v for k, v in zip(keys, values)}
+            if id(keys) == id(keys_floats):
+                cast = float
+            elif id(keys) == id(keys_int64s):
+                cast = int
+            else:
+                cast = str
+            if id(values) == id(values_floats):
+                defval = default_float
+                dtype = np.float32
+            elif id(values) == id(values_int64s):
+                defval = default_int64
+                dtype = np.int64
+            else:
+                defval = default_string
+                if not isinstance(defval, str):
+                    defval = ""
+                dtype = np.str_
+            shape = x.shape
+            if len(x.shape) > 1:
+                x = x.flatten()
+            res = []
+            for i in range(0, x.shape[0]):
+                v = classes.get(cast(x[i]), defval)
+                res.append(v)
+            return (np.array(res, dtype=dtype).reshape(shape),)

--- a/tests/test_utils/reference_implementation_ml.py
+++ b/tests/test_utils/reference_implementation_ml.py
@@ -51,10 +51,7 @@ if 19 >= onnx_opset_version() >= 18:
                 _meth = FusedMatMul._fmatmul11 if transB else FusedMatMul._fmatmul10
             else:
                 _meth = FusedMatMul._fmatmul01 if transB else FusedMatMul._fmatmul00
-
-            def _meth(a, b):
-                return _meth(a, b, alpha)
-
+            _meth = lambda a, b: _meth(a, b, alpha)
             # more recent versions of the operator
             if transBatchA is None:
                 transBatchA = 0
@@ -237,7 +234,9 @@ if 19 >= onnx_opset_version() >= 18:
                         if j >= 0:
                             res[a, i, j] = 1.0
             else:
-                raise RuntimeError(f"This operator is not implemented for shape {x.shape}.")
+                raise RuntimeError(
+                    f"This operator is not implemented for shape {x.shape}."
+                )
 
             if not self.zeros:
                 red = res.sum(axis=len(res.shape) - 1)
@@ -288,8 +287,9 @@ if 19 >= onnx_opset_version() >= 18:
             if len(set(dimensions)) == 1:
                 res = np.concatenate(args, axis=inputdimensions[0])
                 return (res,)
-            raise RuntimeError(f"inputdimensions={
-                               inputdimensions} is not supported yet.")
+            raise RuntimeError(
+                f"inputdimensions={inputdimensions} is not supported yet."
+            )
 
     class Imputer(OpRun):
         op_domain = "ai.onnx.ml"
@@ -390,7 +390,8 @@ if 19 >= onnx_opset_version() >= 18:
                         dict_labels[v] = i
                 if len(dict_labels) == 0:
                     raise RuntimeError(
-                        "int64_vocabulary and string_vocabulary " "cannot be both empty."
+                        "int64_vocabulary and string_vocabulary "
+                        "cannot be both empty."
                     )
 
                 values = []
@@ -417,8 +418,8 @@ if 19 >= onnx_opset_version() >= 18:
                     res.append(x.get(k, 0))
                 return (np.array(res),)
 
-            raise TypeError(f"x must be iterable not {
-                            type(x)}.")  # pragma: no cover
+            raise TypeError(f"x must be iterable not {type(x)}.")  # pragma: no cover
+
 
     class TargetEncoder(OpRun):
         op_domain = "ai.onnx.ml"

--- a/tests/test_utils/utils_backend_onnx.py
+++ b/tests/test_utils/utils_backend_onnx.py
@@ -124,9 +124,9 @@ if onnx_opset_version() >= 18:
                 axes = tuple(axes) if axes is not None else None
                 keepdims = keepdims != 0  # type: ignore
                 return (
-                    np.sqrt(
-                        np.sum(np.square(data), axis=axes, keepdims=keepdims)
-                    ).astype(dtype=data.dtype),
+                    np.sqrt(np.sum(np.square(data), axis=axes, keepdims=keepdims)).astype(
+                        dtype=data.dtype
+                    ),
                 )
 
         class ReduceL2_18(OpRunReduceNumpy):
@@ -135,9 +135,9 @@ if onnx_opset_version() >= 18:
                 axes = tuple(axes) if axes is not None else None
                 keepdims = keepdims != 0  # type: ignore
                 return (
-                    np.sqrt(
-                        np.sum(np.square(data), axis=axes, keepdims=keepdims)
-                    ).astype(dtype=data.dtype),
+                    np.sqrt(np.sum(np.square(data), axis=axes, keepdims=keepdims)).astype(
+                        dtype=data.dtype
+                    ),
                 )
 
         class ReduceMean_1(OpRunReduceNumpy):
@@ -184,9 +184,7 @@ if onnx_opset_version() >= 18:
                 axes = tuple(axes) if axes is not None else None
                 keepdims = keepdims != 0  # type: ignore
                 return (
-                    np.sum(np.square(data), axis=axes, keepdims=keepdims).astype(
-                        data.dtype
-                    ),
+                    np.sum(np.square(data), axis=axes, keepdims=keepdims).astype(data.dtype),
                 )
 
         class ReduceSumSquare_18(OpRunReduceNumpy):
@@ -195,9 +193,7 @@ if onnx_opset_version() >= 18:
                 axes = tuple(axes) if axes is not None else None
                 keepdims = keepdims != 0  # type: ignore
                 return (
-                    np.sum(np.square(data), axis=axes, keepdims=keepdims).astype(
-                        data.dtype
-                    ),
+                    np.sum(np.square(data), axis=axes, keepdims=keepdims).astype(data.dtype),
                 )
 
         class ConstantOfShape(OpRun):
@@ -244,8 +240,7 @@ if onnx_opset_version() >= 18:
                     and not (x.dtype.type is np.str_ and y.dtype.type is np.str_)
                 ):
                     raise RuntimeError(
-                        f"x and y should share the same dtype "
-                        f"{x.dtype} != {y.dtype}"
+                        f"x and y should share the same dtype " f"{x.dtype} != {y.dtype}"
                     )
                 return (np.where(condition, x, y).astype(x.dtype),)
 
@@ -299,6 +294,7 @@ if onnx_opset_version() >= 18:
                 SVMRegressor,
                 TreeEnsembleClassifier,
                 TreeEnsembleRegressor,
+                TargetEncoder,
             ]
         )
 
@@ -634,9 +630,7 @@ def compare_runtime(
         if "is not a registered function/op" in str(e):
             content = onnx_package.load(onx)
             raise OnnxRuntimeAssertionError(
-                "Missing op? '{0}'\nONNX\n{1}\n{2}\n---\n{3}".format(
-                    onx, smodel, e, content
-                )
+                "Missing op? '{0}'\nONNX\n{1}\n{2}\n---\n{3}".format(onx, smodel, e, content)
             )
         raise OnnxRuntimeAssertionError(
             "Unable to load onnx '{0}'\nONNX\n{1}\n{2}.".format(onx, smodel, e)
@@ -660,17 +654,13 @@ def compare_runtime(
             elif len(inp) == 1:
                 inputs = {inp[0].name: input}
             elif isinstance(input, np.ndarray):
-                shape = sum(
-                    i.shape[1] if len(i.shape) == 2 else i.shape[0] for i in inp
-                )
+                shape = sum(i.shape[1] if len(i.shape) == 2 else i.shape[0] for i in inp)
                 if shape == input.shape[1]:
                     inputs = {n.name: input[:, i] for i, n in enumerate(inp)}
                 else:
                     raise OnnxRuntimeAssertionError(
                         "Wrong number of inputs onnx {0} != "
-                        "original shape {1}, onnx='{2}'".format(
-                            len(inp), input.shape, onx
-                        )
+                        "original shape {1}, onnx='{2}'".format(len(inp), input.shape, onx)
                     )
             elif isinstance(input, list):
                 try:
@@ -747,8 +737,9 @@ def compare_runtime(
     if OneOff or OneOffArray:
         if verbose:
             print(
-                "[compare_runtime] OneOff: type(inputs)={} "
-                "len={} OneOffArray={}".format(type(input), len(inputs), OneOffArray)
+                "[compare_runtime] OneOff: type(inputs)={} " "len={} OneOffArray={}".format(
+                    type(input), len(inputs), OneOffArray
+                )
             )
         if len(inputs) == 1 and not OneOffArray:
             name, values = list(inputs.items())[0]
@@ -757,9 +748,10 @@ def compare_runtime(
                 try:
                     one = sess.run(None, {name: input})
                     if lambda_onnx is None:
-                        lambda_onnx = lambda sess=sess, input=input: sess.run(
-                            None, {name: input}
-                        )
+
+                        def lambda_onnx(sess=sess, input=input):
+                            return sess.run(None, {name: input})
+
                     if verbose:
                         import pprint
 
@@ -768,9 +760,7 @@ def compare_runtime(
                     raise expe
                 except Exception as e:
                     if intermediate_steps:
-                        _display_intermediate_steps(
-                            onx, {name: input}, disable_optimisation
-                        )
+                        _display_intermediate_steps(onx, {name: input}, disable_optimisation)
                     if hasattr(sess, "replay_run"):
                         # ReferenceEvaluator
                         res = sess.replay_run()
@@ -801,7 +791,10 @@ def compare_runtime(
                 try:
                     one = sess.run(None, iii)
                     if lambda_onnx is None:
-                        lambda_onnx = lambda sess=sess, iii=iii: sess.run(None, iii)
+
+                        def lambda_onnx(sess=sess, iii=iii):
+                            return sess.run(None, iii)
+
                     if verbose:
                         import pprint
 
@@ -838,9 +831,7 @@ def compare_runtime(
                 if isinstance(output, list):
                     pass
                 elif not isinstance(output, np.ndarray):
-                    raise TypeError(
-                        "output must be an array, not {}".format(type(output))
-                    )
+                    raise TypeError("output must be an array, not {}".format(type(output)))
                 else:
                     output = [output]
     else:
@@ -890,9 +881,7 @@ def compare_runtime(
                     f"Unable to run model\n---\n{res}\n----\n{e}"
                 )
             if verbose:
-                raise OnnxRuntimeAssertionError(
-                    f"Unable to run model due to {e}\n{onx}"
-                )
+                raise OnnxRuntimeAssertionError(f"Unable to run model due to {e}\n{onx}")
             raise OnnxRuntimeAssertionError(f"Unable to run model due to {e}")
         if verbose:
             print("[compare_runtime] done type={}".format(type(output)))
@@ -944,8 +933,9 @@ def compare_runtime(
         else:
             smodel = ""
         raise OnnxRuntimeAssertionError(
-            "Model '{0}' has discrepencies with backend="
-            "'onnx'.\n{1}: {2}{3}".format(onx, type(e), e, smodel)
+            "Model '{0}' has discrepencies with backend=" "'onnx'.\n{1}: {2}{3}".format(
+                onx, type(e), e, smodel
+            )
         )
 
     return output0, lambda_onnx
@@ -971,8 +961,9 @@ def _post_process_output(res):
         mi = min(ls)
         if mi != max(ls):
             raise NotImplementedError(
-                "Unable to postprocess various number of "
-                "outputs in [{0}, {1}]".format(min(ls), max(ls))
+                "Unable to postprocess various number of " "outputs in [{0}, {1}]".format(
+                    min(ls), max(ls)
+                )
             )
         if mi > 1:
             output = []
@@ -988,9 +979,7 @@ def _post_process_output(res):
             if len(res) == 1:
                 return res
             if len(res[0]) != 1:
-                raise NotImplementedError(
-                    "Not conversion implemented for {0}".format(res)
-                )
+                raise NotImplementedError("Not conversion implemented for {0}".format(res))
             st = [r[0] for r in res]
             return np.vstack(st)
         return res
@@ -1037,8 +1026,9 @@ def _compare_expected(
                 )
             if len(expected) != len(output):
                 raise OnnxRuntimeAssertionError(
-                    "Unexpected number of outputs '{0}', "
-                    "expected={1}, got={2}".format(onnx, len(expected), len(output))
+                    "Unexpected number of outputs '{0}', " "expected={1}, got={2}".format(
+                        onnx, len(expected), len(output)
+                    )
                 )
             for exp, out in zip(expected, output):
                 _compare_expected(
@@ -1062,9 +1052,7 @@ def _compare_expected(
         for k, v in output.items():
             if k not in expected:
                 continue
-            msg = compare_outputs(
-                expected[k], v, decimal=decimal, verbose=verbose, **kwargs
-            )
+            msg = compare_outputs(expected[k], v, decimal=decimal, verbose=verbose, **kwargs)
             if msg:
                 if hasattr(sess, "replay_run"):
                     # ReferenceEvaluator
@@ -1092,28 +1080,23 @@ def _compare_expected(
                 if len(ex) > 170:
                     ex = ex[:170] + "..."
                 raise OnnxRuntimeAssertionError(
-                    "More than one output when 1 is expected "
-                    "for onnx '{0}'\n{1}".format(onnx, ex)
+                    "More than one output when 1 is expected " "for onnx '{0}'\n{1}".format(
+                        onnx, ex
+                    )
                 )
             output = output[-1]
         if not isinstance(output, np.ndarray):
             raise OnnxRuntimeAssertionError(
-                "output must be an array for onnx '{0}' not {1}".format(
-                    onnx, type(output)
-                )
+                "output must be an array for onnx '{0}' not {1}".format(onnx, type(output))
             )
-        if classes is not None and (
-            expected.dtype == np.str_ or expected.dtype.char == "U"
-        ):
+        if classes is not None and (expected.dtype == np.str_ or expected.dtype.char == "U"):
             try:
                 output = np.array([classes[cl] for cl in output])
             except IndexError as e:
                 raise RuntimeError(
                     "Unable to handle\n{}\n{}\n{}".format(expected, output, classes)
                 ) from e
-        msg = compare_outputs(
-            expected, output, decimal=decimal, verbose=verbose, **kwargs
-        )
+        msg = compare_outputs(expected, output, decimal=decimal, verbose=verbose, **kwargs)
         if isinstance(msg, ExpectedAssertionError):
             raise msg
         if msg:
@@ -1125,9 +1108,7 @@ def _compare_expected(
                     f"...\n---\n{res}\n----\n{msg}"
                 )
             elif verbose:
-                raise OnnxRuntimeAssertionError(
-                    f"Unexpected output in model {onnx}\n{msg}"
-                )
+                raise OnnxRuntimeAssertionError(f"Unexpected output in model {onnx}\n{msg}")
             raise OnnxRuntimeAssertionError(
                 f"Unexpected output ({type(sess)} - {dir(sess)})\n{msg}"
             )
@@ -1157,8 +1138,9 @@ def _compare_expected(
             tested += 1
         else:
             raise OnnxRuntimeAssertionError(
-                "Unexpected type for expected output ({1}) "
-                "and onnx '{0}'".format(onnx, type(expected))
+                "Unexpected type for expected output ({1}) " "and onnx '{0}'".format(
+                    onnx, type(expected)
+                )
             )
     if tested == 0:
         raise OnnxRuntimeAssertionError("No test for onnx '{0}'".format(onnx))

--- a/tests/test_utils/utils_backend_onnx.py
+++ b/tests/test_utils/utils_backend_onnx.py
@@ -124,9 +124,9 @@ if onnx_opset_version() >= 18:
                 axes = tuple(axes) if axes is not None else None
                 keepdims = keepdims != 0  # type: ignore
                 return (
-                    np.sqrt(np.sum(np.square(data), axis=axes, keepdims=keepdims)).astype(
-                        dtype=data.dtype
-                    ),
+                    np.sqrt(
+                        np.sum(np.square(data), axis=axes, keepdims=keepdims)
+                    ).astype(dtype=data.dtype),
                 )
 
         class ReduceL2_18(OpRunReduceNumpy):
@@ -135,9 +135,9 @@ if onnx_opset_version() >= 18:
                 axes = tuple(axes) if axes is not None else None
                 keepdims = keepdims != 0  # type: ignore
                 return (
-                    np.sqrt(np.sum(np.square(data), axis=axes, keepdims=keepdims)).astype(
-                        dtype=data.dtype
-                    ),
+                    np.sqrt(
+                        np.sum(np.square(data), axis=axes, keepdims=keepdims)
+                    ).astype(dtype=data.dtype),
                 )
 
         class ReduceMean_1(OpRunReduceNumpy):
@@ -184,7 +184,9 @@ if onnx_opset_version() >= 18:
                 axes = tuple(axes) if axes is not None else None
                 keepdims = keepdims != 0  # type: ignore
                 return (
-                    np.sum(np.square(data), axis=axes, keepdims=keepdims).astype(data.dtype),
+                    np.sum(np.square(data), axis=axes, keepdims=keepdims).astype(
+                        data.dtype
+                    ),
                 )
 
         class ReduceSumSquare_18(OpRunReduceNumpy):
@@ -193,7 +195,9 @@ if onnx_opset_version() >= 18:
                 axes = tuple(axes) if axes is not None else None
                 keepdims = keepdims != 0  # type: ignore
                 return (
-                    np.sum(np.square(data), axis=axes, keepdims=keepdims).astype(data.dtype),
+                    np.sum(np.square(data), axis=axes, keepdims=keepdims).astype(
+                        data.dtype
+                    ),
                 )
 
         class ConstantOfShape(OpRun):
@@ -240,7 +244,8 @@ if onnx_opset_version() >= 18:
                     and not (x.dtype.type is np.str_ and y.dtype.type is np.str_)
                 ):
                     raise RuntimeError(
-                        f"x and y should share the same dtype " f"{x.dtype} != {y.dtype}"
+                        f"x and y should share the same dtype "
+                        f"{x.dtype} != {y.dtype}"
                     )
                 return (np.where(condition, x, y).astype(x.dtype),)
 
@@ -287,6 +292,7 @@ if onnx_opset_version() >= 18:
                 LinearRegressor,
                 Normalizer,
                 OneHotEncoder,
+                TargetEncoder,
                 TfIdfVectorizer,
                 Scaler,
                 Scan,
@@ -294,7 +300,6 @@ if onnx_opset_version() >= 18:
                 SVMRegressor,
                 TreeEnsembleClassifier,
                 TreeEnsembleRegressor,
-                TargetEncoder,
             ]
         )
 
@@ -630,7 +635,9 @@ def compare_runtime(
         if "is not a registered function/op" in str(e):
             content = onnx_package.load(onx)
             raise OnnxRuntimeAssertionError(
-                "Missing op? '{0}'\nONNX\n{1}\n{2}\n---\n{3}".format(onx, smodel, e, content)
+                "Missing op? '{0}'\nONNX\n{1}\n{2}\n---\n{3}".format(
+                    onx, smodel, e, content
+                )
             )
         raise OnnxRuntimeAssertionError(
             "Unable to load onnx '{0}'\nONNX\n{1}\n{2}.".format(onx, smodel, e)
@@ -654,13 +661,17 @@ def compare_runtime(
             elif len(inp) == 1:
                 inputs = {inp[0].name: input}
             elif isinstance(input, np.ndarray):
-                shape = sum(i.shape[1] if len(i.shape) == 2 else i.shape[0] for i in inp)
+                shape = sum(
+                    i.shape[1] if len(i.shape) == 2 else i.shape[0] for i in inp
+                )
                 if shape == input.shape[1]:
                     inputs = {n.name: input[:, i] for i, n in enumerate(inp)}
                 else:
                     raise OnnxRuntimeAssertionError(
                         "Wrong number of inputs onnx {0} != "
-                        "original shape {1}, onnx='{2}'".format(len(inp), input.shape, onx)
+                        "original shape {1}, onnx='{2}'".format(
+                            len(inp), input.shape, onx
+                        )
                     )
             elif isinstance(input, list):
                 try:
@@ -737,9 +748,8 @@ def compare_runtime(
     if OneOff or OneOffArray:
         if verbose:
             print(
-                "[compare_runtime] OneOff: type(inputs)={} " "len={} OneOffArray={}".format(
-                    type(input), len(inputs), OneOffArray
-                )
+                "[compare_runtime] OneOff: type(inputs)={} "
+                "len={} OneOffArray={}".format(type(input), len(inputs), OneOffArray)
             )
         if len(inputs) == 1 and not OneOffArray:
             name, values = list(inputs.items())[0]
@@ -748,10 +758,9 @@ def compare_runtime(
                 try:
                     one = sess.run(None, {name: input})
                     if lambda_onnx is None:
-
-                        def lambda_onnx(sess=sess, input=input):
-                            return sess.run(None, {name: input})
-
+                        lambda_onnx = lambda sess=sess, input=input: sess.run(
+                            None, {name: input}
+                        )
                     if verbose:
                         import pprint
 
@@ -760,7 +769,9 @@ def compare_runtime(
                     raise expe
                 except Exception as e:
                     if intermediate_steps:
-                        _display_intermediate_steps(onx, {name: input}, disable_optimisation)
+                        _display_intermediate_steps(
+                            onx, {name: input}, disable_optimisation
+                        )
                     if hasattr(sess, "replay_run"):
                         # ReferenceEvaluator
                         res = sess.replay_run()
@@ -791,10 +802,7 @@ def compare_runtime(
                 try:
                     one = sess.run(None, iii)
                     if lambda_onnx is None:
-
-                        def lambda_onnx(sess=sess, iii=iii):
-                            return sess.run(None, iii)
-
+                        lambda_onnx = lambda sess=sess, iii=iii: sess.run(None, iii)
                     if verbose:
                         import pprint
 
@@ -831,7 +839,9 @@ def compare_runtime(
                 if isinstance(output, list):
                     pass
                 elif not isinstance(output, np.ndarray):
-                    raise TypeError("output must be an array, not {}".format(type(output)))
+                    raise TypeError(
+                        "output must be an array, not {}".format(type(output))
+                    )
                 else:
                     output = [output]
     else:
@@ -881,7 +891,9 @@ def compare_runtime(
                     f"Unable to run model\n---\n{res}\n----\n{e}"
                 )
             if verbose:
-                raise OnnxRuntimeAssertionError(f"Unable to run model due to {e}\n{onx}")
+                raise OnnxRuntimeAssertionError(
+                    f"Unable to run model due to {e}\n{onx}"
+                )
             raise OnnxRuntimeAssertionError(f"Unable to run model due to {e}")
         if verbose:
             print("[compare_runtime] done type={}".format(type(output)))
@@ -933,9 +945,8 @@ def compare_runtime(
         else:
             smodel = ""
         raise OnnxRuntimeAssertionError(
-            "Model '{0}' has discrepencies with backend=" "'onnx'.\n{1}: {2}{3}".format(
-                onx, type(e), e, smodel
-            )
+            "Model '{0}' has discrepencies with backend="
+            "'onnx'.\n{1}: {2}{3}".format(onx, type(e), e, smodel)
         )
 
     return output0, lambda_onnx
@@ -961,9 +972,8 @@ def _post_process_output(res):
         mi = min(ls)
         if mi != max(ls):
             raise NotImplementedError(
-                "Unable to postprocess various number of " "outputs in [{0}, {1}]".format(
-                    min(ls), max(ls)
-                )
+                "Unable to postprocess various number of "
+                "outputs in [{0}, {1}]".format(min(ls), max(ls))
             )
         if mi > 1:
             output = []
@@ -979,7 +989,9 @@ def _post_process_output(res):
             if len(res) == 1:
                 return res
             if len(res[0]) != 1:
-                raise NotImplementedError("Not conversion implemented for {0}".format(res))
+                raise NotImplementedError(
+                    "Not conversion implemented for {0}".format(res)
+                )
             st = [r[0] for r in res]
             return np.vstack(st)
         return res
@@ -1026,9 +1038,8 @@ def _compare_expected(
                 )
             if len(expected) != len(output):
                 raise OnnxRuntimeAssertionError(
-                    "Unexpected number of outputs '{0}', " "expected={1}, got={2}".format(
-                        onnx, len(expected), len(output)
-                    )
+                    "Unexpected number of outputs '{0}', "
+                    "expected={1}, got={2}".format(onnx, len(expected), len(output))
                 )
             for exp, out in zip(expected, output):
                 _compare_expected(
@@ -1052,7 +1063,9 @@ def _compare_expected(
         for k, v in output.items():
             if k not in expected:
                 continue
-            msg = compare_outputs(expected[k], v, decimal=decimal, verbose=verbose, **kwargs)
+            msg = compare_outputs(
+                expected[k], v, decimal=decimal, verbose=verbose, **kwargs
+            )
             if msg:
                 if hasattr(sess, "replay_run"):
                     # ReferenceEvaluator
@@ -1080,23 +1093,28 @@ def _compare_expected(
                 if len(ex) > 170:
                     ex = ex[:170] + "..."
                 raise OnnxRuntimeAssertionError(
-                    "More than one output when 1 is expected " "for onnx '{0}'\n{1}".format(
-                        onnx, ex
-                    )
+                    "More than one output when 1 is expected "
+                    "for onnx '{0}'\n{1}".format(onnx, ex)
                 )
             output = output[-1]
         if not isinstance(output, np.ndarray):
             raise OnnxRuntimeAssertionError(
-                "output must be an array for onnx '{0}' not {1}".format(onnx, type(output))
+                "output must be an array for onnx '{0}' not {1}".format(
+                    onnx, type(output)
+                )
             )
-        if classes is not None and (expected.dtype == np.str_ or expected.dtype.char == "U"):
+        if classes is not None and (
+            expected.dtype == np.str_ or expected.dtype.char == "U"
+        ):
             try:
                 output = np.array([classes[cl] for cl in output])
             except IndexError as e:
                 raise RuntimeError(
                     "Unable to handle\n{}\n{}\n{}".format(expected, output, classes)
                 ) from e
-        msg = compare_outputs(expected, output, decimal=decimal, verbose=verbose, **kwargs)
+        msg = compare_outputs(
+            expected, output, decimal=decimal, verbose=verbose, **kwargs
+        )
         if isinstance(msg, ExpectedAssertionError):
             raise msg
         if msg:
@@ -1108,7 +1126,9 @@ def _compare_expected(
                     f"...\n---\n{res}\n----\n{msg}"
                 )
             elif verbose:
-                raise OnnxRuntimeAssertionError(f"Unexpected output in model {onnx}\n{msg}")
+                raise OnnxRuntimeAssertionError(
+                    f"Unexpected output in model {onnx}\n{msg}"
+                )
             raise OnnxRuntimeAssertionError(
                 f"Unexpected output ({type(sess)} - {dir(sess)})\n{msg}"
             )
@@ -1138,9 +1158,8 @@ def _compare_expected(
             tested += 1
         else:
             raise OnnxRuntimeAssertionError(
-                "Unexpected type for expected output ({1}) " "and onnx '{0}'".format(
-                    onnx, type(expected)
-                )
+                "Unexpected type for expected output ({1}) "
+                "and onnx '{0}'".format(onnx, type(expected))
             )
     if tested == 0:
         raise OnnxRuntimeAssertionError("No test for onnx '{0}'".format(onnx))


### PR DESCRIPTION
This PR implements a converter and a shape calculator for the TargetEncoder class introduced in Scikit-learn 1.5. The code follows much of the implementation of the converter for Ordinal Encoder. 

A partial suit of tests is already implemented, but there is at least a couple of additional tests that I would like to add (missing values and using the smooth parameter from sklearn, even though I think it shouldn't matter).