### PR TITLE
Remove import of `split_complex_to_pairs`

### DIFF
--- a/skl2onnx/proto/__init__.py
+++ b/skl2onnx/proto/__init__.py
@@ -18,11 +18,6 @@ except ImportError:
     # onnx is too old.
     pass
 
-try:
-    from onnx.helper import _split_complex_to_pairs as split_complex_to_pairs
-except ImportError:
-    from onnx.helper import split_complex_to_pairs
-
 
 def get_opset_number_from_onnx():
     """


### PR DESCRIPTION
It seems to be unused. The function is made internal in onnx 1.18.