### PR TITLE
Add `__sklearn_is_fitted__` to CastTransformer

### DIFF
--- a/skl2onnx/sklapi/cast_transformer.py
+++ b/skl2onnx/sklapi/cast_transformer.py
@@ -27,6 +27,9 @@ class CastTransformer(TransformerMixin, BaseEstimator):
     def __init__(self, *, dtype=np.float32):
         self.dtype = dtype
 
+    def __sklearn_is_fitted__(self):
+        return True
+
     def _cast(self, a, name):
         if not isinstance(a, np.ndarray):
             if hasattr(a, "values") and hasattr(a, "iloc"):


### PR DESCRIPTION
This commit adds the `__sklearn_is_fitted__` method to the `CastTransformer` class. 
This method is used by scikit-learn to determine if the transformer is fitted. 
Adding this method prevents a warning from being raised when the transformer is used in a pipeline.