### PR TITLE
Fix sigmoid calibration for Pipeline-wrapped estimators

### DIFF
--- a/skl2onnx/operator_converters/pipelines.py
+++ b/skl2onnx/operator_converters/pipelines.py
@@ -15,11 +15,17 @@ def convert_pipeline(
 ):
     model = operator.raw_operator
     inputs = operator.inputs
+    use_raw_scores = scope.get_options(operator.raw_operator, dict(raw_scores=False))[
+        "raw_scores"
+    ]
     for step in model.steps:
         step_model = step[1]
         if is_classifier(step_model) or isinstance(step_model, Pipeline):
             scope.add_options(id(step_model), options={"zipmap": False})
             container.add_options(id(step_model), options={"zipmap": False})
+            if use_raw_scores and container.has_options(step_model, "raw_scores"):
+                container.add_options(id(step_model), {"raw_scores": True})
+                scope.add_options(id(step_model), {"raw_scores": True})
         outputs = _parse_sklearn(scope, step_model, inputs, custom_parsers=None)
         inputs = outputs
     if len(outputs) != len(operator.outputs):

--- a/tests/test_sklearn_calibrated_classifier_cv_converter.py
+++ b/tests/test_sklearn_calibrated_classifier_cv_converter.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_almost_equal
 from onnxruntime import __version__ as ort_version
 from sklearn import __version__ as sklearn_version
 from sklearn.calibration import CalibratedClassifierCV
-from sklearn.datasets import load_digits, load_iris
+from sklearn.datasets import load_digits, load_iris, make_classification
 from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier
 
 try:
@@ -433,6 +433,40 @@ class TestSklearnCalibratedClassifierCVConverters(unittest.TestCase):
                     model_onnx,
                     basename=f"SklearnCalibratedClassifierBinary{name}SVC2",
                 )
+
+    @unittest.skipIf(
+        pv.Version(ort_version) < pv.Version("0.5.0"), reason="not available"
+    )
+    @ignore_warnings(category=(FutureWarning, ConvergenceWarning, DeprecationWarning))
+    def test_model_calibrated_classifier_cv_sigmoid_pipeline(self):
+        from sklearn.ensemble import GradientBoostingClassifier
+        from sklearn.pipeline import Pipeline
+        from sklearn.preprocessing import FunctionTransformer
+
+        X, y = make_classification(n_samples=500, n_features=20, random_state=42)
+        X = np.abs(X).astype(np.float32)
+
+        clf = GradientBoostingClassifier(n_estimators=20, random_state=42)
+        pipe = Pipeline([("id", FunctionTransformer()), ("clf", clf)])
+
+        for ensemble in [True, False]:
+            with self.subTest(ensemble=ensemble):
+                cal = CalibratedClassifierCV(pipe, method="sigmoid", ensemble=ensemble)
+                cal.fit(X, y)
+
+                model_onnx = convert_sklearn(
+                    cal,
+                    "unused",
+                    [("input", FloatTensorType([None, X.shape[1]]))],
+                    target_opset=TARGET_OPSET,
+                    options={id(cal): {"zipmap": False}},
+                )
+                sess = InferenceSession(
+                    model_onnx.SerializeToString(),
+                    providers=["CPUExecutionProvider"],
+                )
+                res = sess.run(None, {"input": X[:20]})
+                assert_almost_equal(cal.predict_proba(X[:20]), res[1], decimal=4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fix sigmoid calibration for Pipeline-wrapped estimators

Fixes #1246

### Problem

When `CalibratedClassifierCV(method='sigmoid')` wraps a `Pipeline`, the ONNX export produces incorrect probabilities. The `raw_scores` option is set on the Pipeline by the calibrated classifier converter, but the Pipeline converter never propagates it to the inner classifier. The sigmoid calibration `expit(-(a*x + b))` is then applied to probability outputs instead of raw decision function scores.

### Fix

Propagate `raw_scores` from the Pipeline to its classifier steps in `convert_pipeline` (`skl2onnx/operator_converters/pipelines.py`). The pattern for reading and forwarding `raw_scores` to sub-estimators was mimicked from `skl2onnx/operator_converters/bagging.py` (lines 30–32).

### Changes

- **`skl2onnx/operator_converters/pipelines.py`**: Read the Pipeline's `raw_scores` option and forward it to classifier steps that support it.
- **`tests/test_sklearn_calibrated_classifier_cv_converter.py`**: Add `test_model_calibrated_classifier_cv_sigmoid_pipeline` covering both `ensemble=True` and `ensemble=False`.

### Verification

Reproducer output after fix:
```
[OK] bare classifier                 max_diff=0.000000  broken=0/500
[OK] Pipeline(identity+clf)          max_diff=0.000000  broken=0/500
```

No regressions in existing pipeline or calibrated classifier tests.