### PR TITLE
Fix BayesianRidge converter with return_std=True

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -2,6 +2,8 @@
 
 ## 1.21.0
 
+* Fix BayesianRidge standard-deviation conversion to use the correct
+  predictive variance.
 * Updated CI to test scikit-learn==1.9.0 while keeping scikit-learn==1.8.0
   [#1257](https://github.com/onnx/sklearn-onnx/issues/1257)
 * Supports DummyRegressor and DummyClassifier [#1238](https://github.com/onnx/sklearn-onnx/issues/1238)

--- a/skl2onnx/operator_converters/linear_regressor.py
+++ b/skl2onnx/operator_converters/linear_regressor.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
+from sklearn import __version__ as sklearn_version
+
 from ..common._apply_operation import (
     apply_cast,
     apply_add,
     apply_concat,
     apply_sqrt,
     apply_div,
+    apply_mul,
     apply_sub,
     apply_reshape,
 )
@@ -30,6 +33,15 @@ from ..algebra.onnx_ops import (
     OnnxReshape,
     OnnxSigmoid,
 )
+
+
+def _sklearn_version_release():
+    try:
+        import packaging.version as pv
+
+        return pv.Version(sklearn_version).release[:2]
+    except ImportError:
+        return tuple(int(part) for part in sklearn_version.split(".")[:2])
 
 
 def convert_sklearn_linear_regressor(
@@ -132,26 +144,30 @@ def convert_sklearn_bayesian_ridge(
         return
 
     proto_dtype = guess_proto_type(operator.inputs[0].type)
-    if hasattr(op, "normalize") and op.normalize:
-        # if self.normalize:
-        #     X = (X - self.X_offset_) / self.X_scale_
+    sklearn_release = _sklearn_version_release()
+    # Before 1.2, normalize=True centered and scaled the variance features.
+    # Starting with 1.9, predict always centers them without scaling.
+    legacy_normalize = sklearn_release < (1, 2) and getattr(op, "_normalize", False)
+    if sklearn_release >= (1, 9) or legacy_normalize:
         offset = scope.get_unique_variable_name("offset")
         container.add_initializer(
             offset, proto_dtype, op.X_offset_.shape, op.X_offset_.ravel().tolist()
         )
-        scale = scope.get_unique_variable_name("scale")
-        container.add_initializer(
-            scale, proto_dtype, op.X_scale_.shape, op.X_scale_.ravel().tolist()
-        )
         centered = scope.get_unique_variable_name("centered")
         apply_sub(scope, [operator.inputs[0].full_name, offset], centered, container)
-        scaled = scope.get_unique_variable_name("scaled")
-        apply_div(scope, [centered, scale], scaled, container)
-        input_name = scaled
+        input_name = centered
+        if legacy_normalize:
+            scale = scope.get_unique_variable_name("scale")
+            container.add_initializer(
+                scale, proto_dtype, op.X_scale_.shape, op.X_scale_.ravel().tolist()
+            )
+            scaled = scope.get_unique_variable_name("scaled")
+            apply_div(scope, [centered, scale], scaled, container)
+            input_name = scaled
     else:
         input_name = operator.inputs[0].full_name
 
-    # sigmas_squared_data = (np.dot(X, self.sigma_) * X).sum(axis=1)
+    # Compute the row-wise quadratic form x.T @ sigma_ @ x.
     sigma = scope.get_unique_variable_name("sigma")
     container.add_initializer(
         sigma, proto_dtype, op.sigma_.shape, op.sigma_.ravel().tolist()
@@ -163,11 +179,13 @@ def convert_sklearn_bayesian_ridge(
         sigmaed0,
         name=scope.get_unique_operator_name("MatMul"),
     )
+    weighted = scope.get_unique_variable_name("weighted")
+    apply_mul(scope, [sigmaed0, input_name], weighted, container)
     sigmaed = scope.get_unique_variable_name("sigma")
     if container.target_opset < 13:
         container.add_node(
             "ReduceSum",
-            sigmaed0,
+            weighted,
             sigmaed,
             axes=[1],
             name=scope.get_unique_operator_name("ReduceSum"),
@@ -177,7 +195,7 @@ def convert_sklearn_bayesian_ridge(
         container.add_initializer(axis_name, onnx_proto.TensorProto.INT64, [1], [1])
         container.add_node(
             "ReduceSum",
-            [sigmaed0, axis_name],
+            [weighted, axis_name],
             sigmaed,
             name=scope.get_unique_operator_name("ReduceSum"),
         )

--- a/skl2onnx/shape_calculators/linear_regressor.py
+++ b/skl2onnx/shape_calculators/linear_regressor.py
@@ -49,7 +49,7 @@ def calculate_bayesian_ridge_output_shapes(operator):
     else:
         operator.outputs[0].type = cls_type([N, 1])
 
-    if len(operator.inputs) == 2:
+    if len(operator.outputs) == 2:
         # option return_std is True
         operator.outputs[1].type = cls_type([N, 1])
 

--- a/tests/test_sklearn_glm_regressor_converter.py
+++ b/tests/test_sklearn_glm_regressor_converter.py
@@ -6,7 +6,7 @@ import unittest
 import packaging.version as pv
 import onnx
 import numpy
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose, assert_almost_equal
 
 try:
     # scikit-learn >= 0.22
@@ -59,6 +59,57 @@ BACKEND = (
     if pv.Version(onnx.__version__) < pv.Version("1.16.0")
     else "onnx;onnxruntime"
 )
+
+
+def _fit_bayesian_ridge_std_model(dtype):
+    X_train = numpy.array(
+        [
+            [8.2, -3.4, 5.1, 12.0],
+            [9.7, -1.2, 7.4, 10.5],
+            [11.3, -4.8, 6.2, 14.1],
+            [7.1, -2.5, 9.0, 11.7],
+            [12.8, -0.7, 4.3, 15.6],
+            [10.4, -5.1, 8.5, 9.4],
+            [6.6, -1.8, 3.7, 13.3],
+            [13.5, -3.9, 7.8, 16.2],
+            [8.9, -6.0, 5.6, 10.1],
+            [14.2, -2.2, 9.3, 12.8],
+            [9.1, -4.1, 4.8, 17.0],
+            [11.8, -1.5, 8.1, 8.7],
+        ],
+        dtype=dtype,
+    )
+    y_train = numpy.array(
+        [18.1, 25.4, 20.2, 28.7, 21.9, 31.3, 12.8, 27.6, 22.4, 35.1, 16.7, 30.8],
+        dtype=dtype,
+    )
+    X_test = numpy.array(
+        [
+            [7.8, -2.9, 6.7, 14.8],
+            [12.1, -5.4, 3.9, 9.8],
+            [15.0, -0.9, 8.8, 18.1],
+            [9.6, -3.7, 10.2, 11.3],
+        ],
+        dtype=dtype,
+    )
+    model = linear_model.BayesianRidge().fit(X_train, y_train)
+    return model, X_test
+
+
+def _bayesian_ridge_variance_input(model, X):
+    sklearn_release = pv.Version(sklearn_version).release[:2]
+    if sklearn_release >= (1, 9):
+        return X - model.X_offset_
+    if sklearn_release < (1, 2) and getattr(model, "_normalize", False):
+        return (X - model.X_offset_) / model.X_scale_
+    return X
+
+
+def _bayesian_ridge_std_reference(model, X):
+    variance_input = _bayesian_ridge_variance_input(model, X)
+    projected = numpy.matmul(variance_input, model.sigma_)
+    quadratic = numpy.sum(projected * variance_input, axis=1)
+    return numpy.sqrt(quadratic + 1.0 / model.alpha_)
 
 
 class TestGLMRegressorConverter(unittest.TestCase):
@@ -536,34 +587,54 @@ class TestGLMRegressorConverter(unittest.TestCase):
 
     @ignore_warnings(category=(FutureWarning, ConvergenceWarning))
     def test_model_bayesian_ridge_return_std(self):
-        model, X = fit_regression_model(
-            linear_model.BayesianRidge(), n_features=2, n_samples=20
-        )
-        model_onnx = convert_sklearn(
-            model,
-            "bayesian ridge",
-            [("input", FloatTensorType([None, X.shape[1]]))],
-            options={linear_model.BayesianRidge: {"return_std": True}},
-            target_opset=TARGET_OPSET,
-        )
-        self.assertIsNotNone(model_onnx)
+        model, X = _fit_bayesian_ridge_std_model(numpy.float32)
+        self.assertTrue(numpy.all(numpy.abs(model.X_offset_) > 1.0))
 
-        sess = InferenceSession(
-            model_onnx.SerializeToString(), providers=["CPUExecutionProvider"]
-        )
-        outputs = sess.run(None, {"input": X})
-        pred, std = model.predict(X, return_std=True)
-        assert_almost_equal(pred, outputs[0].ravel(), decimal=4)
-        assert_almost_equal(std, outputs[1].ravel(), decimal=4)
+        sklearn_mean, sklearn_std = model.predict(X, return_std=True)
+        reference_std = _bayesian_ridge_std_reference(model, X)
+        assert_allclose(sklearn_std, reference_std, rtol=1e-6, atol=1e-6)
+
+        variance_input = _bayesian_ridge_variance_input(model, X)
+        projected = numpy.matmul(variance_input, model.sigma_)
+        quadratic = numpy.sum(projected * variance_input, axis=1)
+        missing_hadamard = numpy.sum(projected, axis=1)
+        self.assertFalse(numpy.allclose(quadratic, missing_hadamard))
+        if pv.Version(sklearn_version).release[:2] >= (1, 9):
+            raw_projected = numpy.matmul(X, model.sigma_)
+            raw_quadratic = numpy.sum(raw_projected * X, axis=1)
+            self.assertFalse(numpy.allclose(quadratic, raw_quadratic))
+
+        for target_opset in (12, 13):
+            with self.subTest(target_opset=target_opset):
+                model_onnx = convert_sklearn(
+                    model,
+                    "bayesian ridge",
+                    [("input", FloatTensorType([None, X.shape[1]]))],
+                    options={linear_model.BayesianRidge: {"return_std": True}},
+                    target_opset=target_opset,
+                )
+                self.assertIsNotNone(model_onnx)
+                self.assertIn("Mul", {node.op_type for node in model_onnx.graph.node})
+
+                std_dims = model_onnx.graph.output[1].type.tensor_type.shape.dim
+                self.assertEqual(len(std_dims), 2)
+                self.assertEqual(std_dims[1].dim_value, 1)
+
+                sess = InferenceSession(
+                    model_onnx.SerializeToString(), providers=["CPUExecutionProvider"]
+                )
+                onnx_mean, onnx_std = sess.run(None, {"input": X})
+                self.assertEqual(onnx_std.shape, (X.shape[0], 1))
+                assert_allclose(sklearn_mean, onnx_mean.ravel(), rtol=1e-5, atol=1e-5)
+                assert_allclose(sklearn_std, onnx_std.ravel(), rtol=1e-5, atol=1e-5)
+                assert_allclose(reference_std, onnx_std.ravel(), rtol=1e-5, atol=1e-5)
 
     @unittest.skipIf(
         pv.Version(ort_version) < pv.Version("1.3.0"), reason="output type"
     )
     @ignore_warnings(category=(FutureWarning, ConvergenceWarning))
     def test_model_bayesian_ridge_return_std_double(self):
-        model, X = fit_regression_model(
-            linear_model.BayesianRidge(), n_features=2, n_samples=100, n_informative=1
-        )
+        model, X = _fit_bayesian_ridge_std_model(numpy.float64)
         model_onnx = convert_sklearn(
             model,
             "bayesian ridge",
@@ -573,14 +644,15 @@ class TestGLMRegressorConverter(unittest.TestCase):
         )
         self.assertIsNotNone(model_onnx)
 
-        X = X.astype(numpy.float64)
         sess = InferenceSession(
             model_onnx.SerializeToString(), providers=["CPUExecutionProvider"]
         )
-        outputs = sess.run(None, {"input": X})
-        pred, std = model.predict(X, return_std=True)
-        assert_almost_equal(pred, outputs[0].ravel())
-        assert_almost_equal(std, outputs[1].ravel(), decimal=4)
+        onnx_mean, onnx_std = sess.run(None, {"input": X})
+        sklearn_mean, sklearn_std = model.predict(X, return_std=True)
+        reference_std = _bayesian_ridge_std_reference(model, X)
+        assert_allclose(sklearn_std, reference_std, rtol=1e-9, atol=1e-9)
+        assert_allclose(sklearn_mean, onnx_mean.ravel(), rtol=1e-7, atol=1e-7)
+        assert_allclose(sklearn_std, onnx_std.ravel(), rtol=1e-7, atol=1e-7)
 
     @ignore_warnings(category=(FutureWarning, ConvergenceWarning))
     def test_model_bayesian_ridge_return_std_normalize(self):


### PR DESCRIPTION
## Summary

- Fix the BayesianRidge standard-deviation graph, which previously summed `X_variance @ sigma_` directly and omitted the multiplication by `X_variance`. The corrected graph computes the full quadratic form `sum((X_variance @ sigma_) * X_variance, axis=1)`.
- Match scikit-learn’s version-specific feature preprocessing when calculating predictive variance.
- Correct the declared standard-deviation output shape to `[N, 1]` without changing mean prediction or conversion when `return_std=False`.
- Add deterministic float32 and float64 regression tests, including coverage of the `ReduceSum` API boundary at opset 13.
## Root cause

The existing uncertainty graph computed:

```python
projected = X_variance @ sigma_
quadratic = projected.sum(axis=1)
```
without computing the Hadamard product at the end of the formula as per [BayesianRidge predict with return_std = True](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/linear_model/_bayes.py#L397-L403) and [https://www.jmlr.org/papers/volume1/tipping01a/tipping01a.pdf](url) (Eq 22)

```python
projected = X_variance @ sigma_ * X_variance
quadratic = projected.sum(axis=1)
```

### Why the previous test passed

The previous test used a two-feature, zero-noise `make_regression` dataset. The resulting BayesianRidge model was  very confident: the expected standard deviations were about `5e-4`.

Although the incorrect ONNX calculation differed from scikit-learn by up to `1.1e-4` on scikit-learn 1.9 (`1.3e-4` on 1.8), the test compared the outputs with `assert_almost_equal(..., decimal=4)`. That assertion accepts absolute differences below  1.5e-4` , so errors exceeding 20% relative still passed.

The generated features also had relatively small fitted offsets (approximately `[-0.18, -0.24]`), making the centering-specific discrepancy smaller still. The new test uses shifted, varied four-feature data, explicit quadratic-form checks, and dtype-appropriate `assert_allclose` tolerances.

## Compatibility

- scikit-learn `<1.2` with fitted `_normalize=True`: use `(X - X_offset_) / X_scale_`.
- scikit-learn `1.2` through `1.8`: use raw `X`.
- scikit-learn `>=1.9`: use `X - X_offset_`.

## Testing

- `pytest -q tests/test_sklearn_glm_regressor_converter.py -k bayesian_ridge` with scikit-learn 1.8.0 and 1.9.0
- `pytest -q tests/test_sklearn_glm_regressor_converter.py --maxfail=1`
- `black --check --diff .`
- `ruff check` on all modified Python files
- `pip wheel . --no-deps`

## Related work

Follow-up to #580, which added `return_std` support for the request in #523. The scikit-learn 1.9 centering behavior was introduced by scikit-learn/scikit-learn#33918.
