### PR TITLE
CI: unbreak ruff lint and move off the archived ruff-action

### DIFF
--- a/.github/workflows/black-ruff.yml
+++ b/.github/workflows/black-ruff.yml
@@ -4,13 +4,16 @@ jobs:
   black-format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - uses: psf/black@stable
         with:
           options: "--diff --check"
           src: "."
+          version: "26.5.1"
   ruff-format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: chartboost/ruff-action@v1
+      - uses: actions/checkout@v7
+      - uses: astral-sh/ruff-action@v4.1.0
+        with:
+          version: "0.16.1"

--- a/docs/tutorial/plot_transformer_discrepancy.py
+++ b/docs/tutorial/plot_transformer_discrepancy.py
@@ -68,8 +68,10 @@ strings = numpy.array(
     [
         "This a sentence.",
         "This a sentence with more characters $^*&'(-...",
-        """var = ClassName(var2, user=mail@anywhere.com, pwd"""
-        """=")_~-('&]@^\\`|[{#")""",
+        (
+            """var = ClassName(var2, user=mail@anywhere.com, pwd"""
+            """=")_~-('&]@^\\`|[{#")"""
+        ),
         "c79857654",
         "https://complex-url.com/;76543u3456?g=hhh&amp;h=23",
         "01-03-05T11:12:13",


### PR DESCRIPTION

Unbreaks the ruff job, which is red on `main` and on every open PR right now, and moves it off an archived action. Part of #1261.

- fix the ISC004 error in `docs/tutorial/plot_transformer_discrepancy.py`
- swap `chartboost/ruff-action@v1` for `astral-sh/ruff-action@v4.1.0`
- pin the ruff and black versions
- move `actions/checkout` off Node 20


ruff 0.16.0 added [ISC004](https://docs.astral.sh/ruff/rules/implicit-string-concatenation-in-collection-literal/), which fires on `docs/tutorial/plot_transformer_discrepancy.py:71`. I checked the older releases: 0.13.3, 0.14.0 and 0.15.0 are all clean, and 0.16.0 is the first one that flags it. Nothing changed in the repo. `pyproject.toml` selects the whole `ISC` family by prefix and the workflow doesn't pin a ruff version, so CI picked up the new rule the moment it shipped.

The two string fragments can't be joined into a single literal because the text ends in `")`, which would give five quotes in a row, so they're wrapped in parentheses instead. The string values are unchanged.

[ChartBoost/ruff-action](https://github.com/ChartBoost/ruff-action) has been archived since October 2024. [astral-sh/ruff-action](https://github.com/astral-sh/ruff-action) is the maintained successor, and `args` and `src` already default to the values this workflow relied on, so the swap is otherwise a no-op. Its README pins the exact tag rather than a floating major (there is no `v4` tag), so this does the same.

Pinning ruff and black is the part that stops this recurring: neither can turn `main` red on its own release schedule any more.


- [x] `ruff check .` is clean at the pinned 0.16.1 (`All checks passed!`)
- [x] `black --check .` is clean at the pinned 26.5.1 (`395 files would be left unchanged`)
- [x] string constants in the edited file are byte-identical before and after, compared via `ast`
- [x] all three action refs resolve: `actions/checkout@v7`, `astral-sh/ruff-action@v4.1.0`, `psf/black@stable`
- [x] both jobs green on a fork run of this exact branch ([run](https://github.com/warmlogic/sklearn-onnx/actions/runs/30836038929)): the action resolved, installed ruff 0.16.1, and `ruff-format-check` and `black-format-check` both passed


Dropping black for `ruff format`, which #1261 asks about. That needs a `line-length` decision first.
